### PR TITLE
centralize acquiring clam socket through get_clamd_socket()

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,11 @@ Start `clamd` if not already running (in a new console window/tab):
 clamd
 ```
 
-The antivirus API runs on port 5008.
+The antivirus API expects to connect to `clamd` over a unix socket. The location of this unix socket can be set by the
+configuration variable `DM_CLAMD_UNIX_SOCKET_PATH`. The default may be fine if you're running a system `clamd` or the
+docker image.
+
+The antivirus API itself runs on port 5008.
 
 Calls to the antivirus API require a valid bearer
 token. For development environments, this defaults to `myToken`. An example request to your local antivirus API

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -14,8 +14,8 @@ def create_app(config_name):
         configs[config_name],
     )
 
-    if not application.config['DM_AV_AUTH_TOKENS']:
-        raise Exception("No DM_AV_AUTH_TOKENS provided")
+    if not application.config['DM_ANTIVIRUS_API_AUTH_TOKENS']:
+        raise Exception("No DM_ANTIVIRUS_API_AUTH_TOKENS provided")
 
     from .main import main as main_blueprint
     from .status import status as status_blueprint

--- a/app/clam.py
+++ b/app/clam.py
@@ -1,0 +1,7 @@
+from flask import current_app
+
+import clamd
+
+
+def get_clamd_socket():
+    return clamd.ClamdUnixSocket(path=current_app.config["DM_CLAMD_UNIX_SOCKET_PATH"])

--- a/app/main/views/scan.py
+++ b/app/main/views/scan.py
@@ -6,6 +6,7 @@ from flask import abort, jsonify, request, current_app
 from dmutils.timing import logged_duration_for_external_request
 
 from .. import main
+from ...clam import get_clamd_socket
 
 
 @main.route('/scan', methods=['POST'])
@@ -16,7 +17,7 @@ def scan():
     file = request.files['document']
 
     try:
-        client = clamd.ClamdUnixSocket()
+        client = get_clamd_socket()
 
         with logged_duration_for_external_request(service='ClamAV', description='instream scan via unix socket'):
             scan_result = client.instream(BytesIO(file.stream.read()))['stream']

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -2,11 +2,12 @@ import clamd
 from flask import request
 
 from . import status
+from ..clam import get_clamd_socket
 from dmutils.status import get_app_status, StatusError
 
 
 def get_clamd_status():
-    client = clamd.ClamdUnixSocket()
+    client = get_clamd_socket()
 
     try:
         if client.ping() == 'PONG':

--- a/config.py
+++ b/config.py
@@ -14,26 +14,27 @@ class Config:
     DM_LOG_LEVEL = 'DEBUG'
     DM_PLAIN_TEXT_LOGS = False
     DM_LOG_PATH = None
-    DM_APP_NAME = 'antivirus'
+    DM_APP_NAME = 'antivirus-api'
 
-    # Feature Flags
-    RAISE_ERROR_ON_MISSING_FEATURES = True
+    DM_CLAMD_UNIX_SOCKET_PATH = "/var/run/clamav/clamd.ctl"
 
     VCAP_SERVICES = None
 
 
 class Test(Config):
-    SERVER_NAME = '127.0.0.1:5100'
+    SERVER_NAME = '127.0.0.1:5008'
     DEBUG = True
     DM_PLAIN_TEXT_LOGS = True
-    DM_ANTIVIRUS_AUTH_TOKENS = 'myToken'
+    DM_LOG_LEVEL = 'CRITICAL'
+
+    DM_ANTIVIRUS_API_AUTH_TOKENS = 'valid-token'
 
 
 class Development(Config):
     DEBUG = True
     DM_PLAIN_TEXT_LOGS = True
 
-    DM_ANTIVIRUS_AUTH_TOKENS = 'myToken'
+    DM_ANTIVIRUS_API_AUTH_TOKENS = 'myToken'
 
 
 class Live(Config):


### PR DESCRIPTION
This should give us increased configurability. I don't know if we'll ever need to offer the TCP option (some people may find it hard to run a unix socket locally for some reason, i don't know), but that would at least be a feasible addition now.

At somepoint soon we should probably be getting some actual tests so our merges can be based on more than *shrug*s.