### PR TITLE
config: set global empty defaults for `_TOKENS` config variables

### DIFF
--- a/config.py
+++ b/config.py
@@ -8,7 +8,8 @@ class Config:
     VERSION = get_version_label(
         os.path.abspath(os.path.dirname(__file__))
     )
-    DM_ANTIVIRUS_AUTH_TOKENS = None
+    DM_ANTIVIRUS_API_AUTH_TOKENS = None
+    DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS = None
     AUTH_REQUIRED = True
     DM_HTTP_PROTO = 'http'
     # Logging


### PR DESCRIPTION
Without these the app will not grab the actual values from the env on startup.