### PR TITLE
status view: use new `additional_checks_internal` for `get_clamd_status` 

### DIFF
--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -398,7 +398,7 @@ def handle_s3_sns():
                 try:
                     notify_client.send_email(
                         current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
-                        template_name="developer_virus_alert",
+                        template_name_or_id="developer_virus_alert",
                         personalisation={
                             "region_name": record["awsRegion"],
                             "bucket_name": s3_bucket_name,

--- a/app/status/views.py
+++ b/app/status/views.py
@@ -26,5 +26,7 @@ def get_clamd_status():
 
 @status.route('/_status')
 def status():
-    return get_app_status(ignore_dependencies='ignore-dependencies' in request.args,
-                          additional_checks=[get_clamd_status])
+    return get_app_status(
+        ignore_dependencies='ignore-dependencies' in request.args,
+        additional_checks_internal=[get_clamd_status],
+    )

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,4 +6,4 @@ Flask==1.0.2
 lxml==4.2.4
 validatesns==0.1.1
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.0#egg=digitalmarketplace-utils==44.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.0#egg=digitalmarketplace-utils==44.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ Flask==1.0.2
 lxml==4.2.4
 validatesns==0.1.1
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@44.0.0#egg=digitalmarketplace-utils==44.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@44.2.0#egg=digitalmarketplace-utils==44.2.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==0.24.0

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -809,7 +809,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                             "region_name": "howth-west-2",
                             "sns_message_id": "424344def",
                         },
-                        template_name="developer_virus_alert",
+                        template_name_or_id="developer_virus_alert",
                     ),
                 ),
                 # expected_tagset


### PR DESCRIPTION
We probably want to consider this to be part of the app and want it to be included in healthchecks.