### PR TITLE
sns: force request.get_json() to give us the json anyway even if the content-type is "text/plain"

### DIFF
--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -32,9 +32,9 @@ def _get_request_body_json():
         "application/json",
         "text/plain",
     ):
-        abort(400, "Unexpected Content-Type, expecting 'application/json'")
+        abort(400, "Unexpected Content-Type, expecting 'application/json' or 'text/plain'")
 
-    data = request.get_json()
+    data = request.get_json(force=True)
 
     if data is None:
         abort(400, "Invalid JSON; must be a valid JSON object")

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -577,9 +577,15 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 assert mock_validate.call_args_list == [((weird_body_dict,), AnySupersetOf({}))]
                 assert mock_handle_subscription_confirmation.called is False
 
+    @pytest.mark.parametrize("content_type", ("application/json", "text/plain",))
     @mock.patch("validatesns.validate", autospec=True)
     @mock.patch("app.callbacks.views.sns._handle_subscription_confirmation", autospec=True)
-    def test_handle_s3_sns_subscription_confirmation(self, mock_handle_subscription_confirmation, mock_validate):
+    def test_handle_s3_sns_subscription_confirmation(
+        self,
+        mock_handle_subscription_confirmation,
+        mock_validate,
+        content_type,
+    ):
         # arbitrary sentinel Response
         mock_handle_subscription_confirmation.return_value = Response("Grain supplies"), 200
 
@@ -589,7 +595,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 res = client.post(
                     "/callbacks/sns/s3/uploaded",
                     data=json.dumps(self._basic_subscription_confirmation_body),
-                    content_type="application/json",
+                    content_type=content_type,
                 )
 
                 assert res.status_code == 200


### PR DESCRIPTION
Also add a test for this.