### PR TITLE
handle_s3_sns: expect "Message" to be a serialized json blob

### DIFF
--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -208,7 +208,15 @@ def handle_s3_sns():
         },
     )
 
-    for record in body_dict["Message"]["Records"]:
+    try:
+        records = json.loads(body_dict["Message"])["Records"]
+    except (ValueError, KeyError, TypeError):
+        current_app.logger.warning("Message contents didn't match expected format: {message_contents!r}", extra={
+            "message_contents": body_dict.get("Message"),
+        })
+        abort(400, f"Message contents didn't match expected format")
+
+    for record in records:
         with logged_duration(
             logger=current_app.logger,
             message=lambda _: (


### PR DESCRIPTION
Turns out S3 through SNS *does* supply us a json dictionary as the payload of the `Message` key, it's just that it's a *json serialized* dictionary. JSON in JSON.

This copes with that and adds some tests around handling of it going wrong.