### PR TITLE
handle_s3_sns: encode tag values in base64 to comply with AWS tags restrictions

### DIFF
--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -430,14 +430,14 @@ def _handle_s3_sns_record(record, message_id):
                     current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
                     template_name_or_id="developer_virus_alert",
                     personalisation={
-                        "region_name": record["awsRegion"],
+                        "region_name": record.get("awsRegion") or "<unknown>",
                         "bucket_name": s3_bucket_name,
                         "object_key": s3_object_key,
                         "object_version": s3_object_version,
-                        "file_name": file_name,
+                        "file_name": file_name or "<unknown>",
                         "clamd_output": ", ".join(clamd_result),
                         "sns_message_id": message_id,
-                        "dm_trace_id": request.trace_id,
+                        "dm_trace_id": request.trace_id or "<unknown>",
                     },
                 )
             except EmailError as e:

--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -299,7 +299,7 @@ def handle_s3_sns():
                     VersionId=s3_object_version,
                 )
 
-            file_name = _filename_from_content_disposition(s3_object["ContentDisposition"] or "")
+            file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
 
             with logged_duration(
                 logger=current_app.logger,

--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -226,224 +226,228 @@ def handle_s3_sns():
         abort(400, f"Message contents didn't match expected format")
 
     for record in records:
+        _handle_s3_sns_record(record, body_dict["MessageId"])
+
+    return jsonify(status="ok", dmTraceId=request.trace_id), 200
+
+
+def _handle_s3_sns_record(record, message_id):
+    with logged_duration(
+        logger=current_app.logger,
+        message=lambda _: (
+            "Handled bucket {s3_bucket_name} key {s3_object_key} version {s3_object_version}"
+            if sys.exc_info()[0] is None else
+            # need to literally format() the exception into message as it's difficult to get it injected into extra
+            "Failed handling {{s3_bucket_name}} key {{s3_object_key}} version {{s3_object_version}}: {!r}".format(
+                sys.exc_info()[1]
+            )
+        ),
+        log_level=logging.INFO,
+        condition=True,
+    ) as log_context:
+        s3_bucket_name = record["s3"]["bucket"]["name"]
+        s3_object_key = record["s3"]["object"]["key"]
+        s3_object_version = record["s3"]["object"]["versionId"]
+        base_log_context = {
+            "s3_bucket_name": s3_bucket_name,
+            "s3_object_key": s3_object_key,
+            "s3_object_version": s3_object_version,
+        }
+        log_context.update(base_log_context)
+
+        # TODO abort if file too big?
+
+        s3_client = boto3.client("s3", region_name=record["awsRegion"])
+
+        with log_external_request(
+            "S3",
+            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            tagging_tag_set = s3_client.get_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )["TagSet"]
+
+        av_status_json_raw = _tag_value_from_tag_set(tagging_tag_set, "avStatus")
+
+        if av_status_json_raw is None:
+            current_app.logger.info(
+                "Object version {s3_object_version} has no 'avStatus' tag - will scan...",
+                extra=base_log_context,
+            )
+        else:
+            current_app.logger.info(
+                "Object version {s3_object_version} already has 'avStatus' tag: {existing_av_status!r} / "
+                "{existing_av_status_raw!r}",
+                extra={
+                    **base_log_context,
+                    "existing_av_status": _attempt_b64decode(av_status_json_raw),
+                    "existing_av_status_raw": av_status_json_raw,
+                },
+            )
+            return
+
+        clamd_client = get_clamd_socket()
+        # first check our clamd is available - there's no point in going and fetching the object if we can't do
+        # anything with it. allow a raised exception to bubble up as a 500, which seems the most appropriate thing
+        # in this case
+        clamd_client.ping()
+
+        # the following two requests (to S3 for the file contents and to clamd for scanning) don't really happen
+        # sequentially as we're going to attempt to stream the data received from one into the other (by passing
+        # the StreamingBody file-like object from this response into .instream(...)), so these logged_duration
+        # sections do NOT *directly* correspond to the file being downloaded and then the file being scanned. The
+        # two activities will overlap in time, something that isn't expressible with logged_duration
+        with log_external_request(
+            "S3",
+            "initiate object download [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            s3_object = s3_client.get_object(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )
+
+        file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
+
         with logged_duration(
             logger=current_app.logger,
             message=lambda _: (
-                "Handled bucket {s3_bucket_name} key {s3_object_key} version {s3_object_version}"
+                "Scanned {file_length}byte file '{file_name}', result {clamd_result}"
                 if sys.exc_info()[0] is None else
-                # need to literally format() the exception into message as it's difficult to get it injected into extra
-                "Failed handling {{s3_bucket_name}} key {{s3_object_key}} version {{s3_object_version}}: {!r}".format(
+                # need to literally format() exception into message as it's difficult to get it injected into extra
+                "Failed scanning {{file_length}}byte file '{{file_name}}': {!r}".format(
                     sys.exc_info()[1]
                 )
             ),
             log_level=logging.INFO,
             condition=True,
-        ) as log_context:
-            s3_bucket_name = record["s3"]["bucket"]["name"]
-            s3_object_key = record["s3"]["object"]["key"]
-            s3_object_version = record["s3"]["object"]["versionId"]
-            base_log_context = {
-                "s3_bucket_name": s3_bucket_name,
-                "s3_object_key": s3_object_key,
-                "s3_object_version": s3_object_version,
-            }
-            log_context.update(base_log_context)
+        ) as log_context_clamd:
+            log_context_clamd.update({
+                "file_length": s3_object["ContentLength"],
+                "file_name": file_name or "<unknown>",
+            })
+            clamd_result = clamd_client.instream(s3_object["Body"])["stream"]
+            log_context_clamd["clamd_result"] = clamd_result
 
-            # TODO abort if file too big?
+        if clamd_result[0] == "ERROR":
+            # let's hope this was a transient error and a later attempt may succeed. hard to know what else to do
+            # in this case - tagging a file with "ERROR" would prevent further attempts.
+            raise UnknownClamdError(f"clamd did not successfully scan file: {clamd_result!r}")
 
-            s3_client = boto3.client("s3", region_name=record["awsRegion"])
-
-            with log_external_request(
-                "S3",
-                "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                tagging_tag_set = s3_client.get_object_tagging(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                )["TagSet"]
-
-            av_status_json_raw = _tag_value_from_tag_set(tagging_tag_set, "avStatus")
-
-            if av_status_json_raw is None:
-                current_app.logger.info(
-                    "Object version {s3_object_version} has no 'avStatus' tag - will scan...",
-                    extra=base_log_context,
+        with logged_duration(
+            logger=current_app.logger,
+            message=lambda _: (
+                "Fetched clamd version string: {clamd_version}"
+                if sys.exc_info()[0] is None else
+                # need to literally format() exception into message as it's difficult to get it injected into extra
+                "Failed fetching clamd version string: {!r}".format(
+                    sys.exc_info()[1]
                 )
-            else:
-                current_app.logger.info(
-                    "Object version {s3_object_version} already has 'avStatus' tag: {existing_av_status!r} / "
-                    "{existing_av_status_raw!r}",
+            ),
+            log_level=logging.DEBUG,
+        ) as log_context_clamd:
+            # hypothetically there is a race condition between the time of scanning the file and fetching the
+            # version here when freshclam could give us a new definition file, making this information incorrect,
+            # but it's a very small possibility
+            clamd_version = clamd_client.version()
+            log_context_clamd.update({"clamd_version": clamd_version})
+
+        # keep in mind we only have 256 chars to play with here, so keep it brief
+        new_av_status = {
+            "result": "pass" if clamd_result[0] == "OK" else "fail",
+            "clamdVerStr": clamd_version,
+            "ts": datetime.datetime.utcnow().isoformat(),
+        }
+        new_av_status_json = json.dumps(new_av_status, separators=(',', ':'))
+        # AWS tags have a limited character set, so we base64-encode this value
+        new_av_status_json_b64 = base64.b64encode(new_av_status_json.encode("utf-8")).decode("ascii")
+
+        # Now we briefly re-check the object's tags to ensure they weren't set by something else while we were
+        # scanning. Note the impossibility of avoiding all possible race conditions as S3's API doesn't allow any
+        # form of locking. What we *can* do is make the possible time period between check-tags and set-tags as
+        # small as possible...
+        with log_external_request(
+            "S3",
+            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            tagging_tag_set = s3_client.get_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )["TagSet"]
+
+        av_status_json_raw = _tag_value_from_tag_set(tagging_tag_set, "avStatus")
+
+        if av_status_json_raw is not None:
+            current_app.logger.warning(
+                "Object was tagged with new 'avStatus' ({existing_av_status_raw!r} / {existing_av_status!r}) while "
+                "we were scanning. Not applying our own 'avStatus' result ({unapplied_av_status_raw!r} / "
+                "{unapplied_av_status!r})",
+                extra={
+                    "existing_av_status_raw": av_status_json_raw,
+                    "existing_av_status": _attempt_b64decode(av_status_json_raw),
+                    "unapplied_av_status_raw": new_av_status_json_b64,
+                    "unapplied_av_status": new_av_status_json,
+                },
+            )
+            return
+
+        tagging_tag_set = _tag_set_updated_with_value(tagging_tag_set, "avStatus", new_av_status_json_b64)
+
+        with log_external_request(
+            "S3",
+            "put object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            s3_client.put_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+                Tagging={"TagSet": tagging_tag_set},
+            )
+
+        if clamd_result[0] != "OK":
+            # TODO? attempt to rectify the situation:
+            # TODO? if this is (still) current version of object:
+            # TODO?     S3: find most recent version of object which is tagged "good"
+            # TODO?     if there is no such version:
+            # TODO?         S3: upload fail whale?
+            # TODO?     else copy that version to become new "current" ver for this key, ensuring to copy its tags
+            # TODO?         note the impossibility of doing this without some race conditions
+
+            notify_client = DMNotifyClient(current_app.config["DM_NOTIFY_API_KEY"])
+            try:
+                notify_client.send_email(
+                    current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
+                    template_name_or_id="developer_virus_alert",
+                    personalisation={
+                        "region_name": record["awsRegion"],
+                        "bucket_name": s3_bucket_name,
+                        "object_key": s3_object_key,
+                        "object_version": s3_object_version,
+                        "file_name": file_name,
+                        "clamd_output": ", ".join(clamd_result),
+                        "sns_message_id": message_id,
+                        "dm_trace_id": request.trace_id,
+                    },
+                )
+            except EmailError as e:
+                current_app.logger.error(
+                    "Failed to send developer_virus_alert email after scanning "
+                    "{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}: {e}",
                     extra={
                         **base_log_context,
-                        "existing_av_status": _attempt_b64decode(av_status_json_raw),
-                        "existing_av_status_raw": av_status_json_raw,
+                        "e": str(e),
                     },
                 )
-                continue
-
-            clamd_client = get_clamd_socket()
-            # first check our clamd is available - there's no point in going and fetching the object if we can't do
-            # anything with it. allow a raised exception to bubble up as a 500, which seems the most appropriate thing
-            # in this case
-            clamd_client.ping()
-
-            # the following two requests (to S3 for the file contents and to clamd for scanning) don't really happen
-            # sequentially as we're going to attempt to stream the data received from one into the other (by passing
-            # the StreamingBody file-like object from this response into .instream(...)), so these logged_duration
-            # sections do NOT *directly* correspond to the file being downloaded and then the file being scanned. The
-            # two activities will overlap in time, something that isn't expressible with logged_duration
-            with log_external_request(
-                "S3",
-                "initiate object download [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                s3_object = s3_client.get_object(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                )
-
-            file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
-
-            with logged_duration(
-                logger=current_app.logger,
-                message=lambda _: (
-                    "Scanned {file_length}byte file '{file_name}', result {clamd_result}"
-                    if sys.exc_info()[0] is None else
-                    # need to literally format() exception into message as it's difficult to get it injected into extra
-                    "Failed scanning {{file_length}}byte file '{{file_name}}': {!r}".format(
-                        sys.exc_info()[1]
-                    )
-                ),
-                log_level=logging.INFO,
-                condition=True,
-            ) as log_context_clamd:
-                log_context_clamd.update({
-                    "file_length": s3_object["ContentLength"],
-                    "file_name": file_name or "<unknown>",
-                })
-                clamd_result = clamd_client.instream(s3_object["Body"])["stream"]
-                log_context_clamd["clamd_result"] = clamd_result
-
-            if clamd_result[0] == "ERROR":
-                # let's hope this was a transient error and a later attempt may succeed. hard to know what else to do
-                # in this case - tagging a file with "ERROR" would prevent further attempts.
-                raise UnknownClamdError(f"clamd did not successfully scan file: {clamd_result!r}")
-
-            with logged_duration(
-                logger=current_app.logger,
-                message=lambda _: (
-                    "Fetched clamd version string: {clamd_version}"
-                    if sys.exc_info()[0] is None else
-                    # need to literally format() exception into message as it's difficult to get it injected into extra
-                    "Failed fetching clamd version string: {!r}".format(
-                        sys.exc_info()[1]
-                    )
-                ),
-                log_level=logging.DEBUG,
-            ) as log_context_clamd:
-                # hypothetically there is a race condition between the time of scanning the file and fetching the
-                # version here when freshclam could give us a new definition file, making this information incorrect,
-                # but it's a very small possibility
-                clamd_version = clamd_client.version()
-                log_context_clamd.update({"clamd_version": clamd_version})
-
-            # keep in mind we only have 256 chars to play with here, so keep it brief
-            new_av_status = {
-                "result": "pass" if clamd_result[0] == "OK" else "fail",
-                "clamdVerStr": clamd_version,
-                "ts": datetime.datetime.utcnow().isoformat(),
-            }
-            new_av_status_json = json.dumps(new_av_status, separators=(',', ':'))
-            # AWS tags have a limited character set, so we base64-encode this value
-            new_av_status_json_b64 = base64.b64encode(new_av_status_json.encode("utf-8")).decode("ascii")
-
-            # Now we briefly re-check the object's tags to ensure they weren't set by something else while we were
-            # scanning. Note the impossibility of avoiding all possible race conditions as S3's API doesn't allow any
-            # form of locking. What we *can* do is make the possible time period between check-tags and set-tags as
-            # small as possible...
-            with log_external_request(
-                "S3",
-                "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                tagging_tag_set = s3_client.get_object_tagging(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                )["TagSet"]
-
-            av_status_json_raw = _tag_value_from_tag_set(tagging_tag_set, "avStatus")
-
-            if av_status_json_raw is not None:
-                current_app.logger.warning(
-                    "Object was tagged with new 'avStatus' ({existing_av_status_raw!r} / {existing_av_status!r}) while "
-                    "we were scanning. Not applying our own 'avStatus' result ({unapplied_av_status_raw!r} / "
-                    "{unapplied_av_status!r})",
-                    extra={
-                        "existing_av_status_raw": av_status_json_raw,
-                        "existing_av_status": _attempt_b64decode(av_status_json_raw),
-                        "unapplied_av_status_raw": new_av_status_json_b64,
-                        "unapplied_av_status": new_av_status_json,
-                    },
-                )
-                continue
-
-            tagging_tag_set = _tag_set_updated_with_value(tagging_tag_set, "avStatus", new_av_status_json_b64)
-
-            with log_external_request(
-                "S3",
-                "put object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                s3_client.put_object_tagging(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                    Tagging={"TagSet": tagging_tag_set},
-                )
-
-            if clamd_result[0] != "OK":
-                # TODO? attempt to rectify the situation:
-                # TODO? if this is (still) current version of object:
-                # TODO?     S3: find most recent version of object which is tagged "good"
-                # TODO?     if there is no such version:
-                # TODO?         S3: upload fail whale?
-                # TODO?     else copy that version to become new "current" ver for this key, ensuring to copy its tags
-                # TODO?         note the impossibility of doing this without some race conditions
-
-                notify_client = DMNotifyClient(current_app.config["DM_NOTIFY_API_KEY"])
-                try:
-                    notify_client.send_email(
-                        current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
-                        template_name_or_id="developer_virus_alert",
-                        personalisation={
-                            "region_name": record["awsRegion"],
-                            "bucket_name": s3_bucket_name,
-                            "object_key": s3_object_key,
-                            "object_version": s3_object_version,
-                            "file_name": file_name,
-                            "clamd_output": ", ".join(clamd_result),
-                            "sns_message_id": body_dict["MessageId"],
-                            "dm_trace_id": request.trace_id,
-                        },
-                    )
-                except EmailError as e:
-                    current_app.logger.error(
-                        "Failed to send developer_virus_alert email after scanning "
-                        "{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}: {e}",
-                        extra={
-                            **base_log_context,
-                            "e": str(e),
-                        },
-                    )
-                    # however we still want this request to return a successful status to signify to SNS that it
-                    # should not attempt to re-send this message
-
-    return jsonify(status="ok", dmTraceId=request.trace_id), 200
+                # however we still want this request to return a successful status to signify to SNS that it
+                # should not attempt to re-send this message

--- a/config.py
+++ b/config.py
@@ -20,6 +20,8 @@ class Config:
 
     DM_CLAMD_UNIX_SOCKET_PATH = "/var/run/clamav/clamd.ctl"
 
+    DM_NOTIFY_API_KEY = None
+
     DM_DEVELOPER_VIRUS_ALERT_EMAIL = "developer-virus-alert@example.com"
     NOTIFY_TEMPLATES = {
         "developer_virus_alert": "70986093-4f54-4b2e-883e-d88456455385",

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -1060,7 +1060,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 # initial_tagset
                 {"existing": "tag123"},
                 # concurrent_new_tagset
-                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}')},
+                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101","mead":"Übermensch"}')},
                 # clamd_instream_retval
                 {"stream": ("FOUND", "After him, boy!",)},
                 # expected_exception
@@ -1127,8 +1127,11 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                             (),
                         ),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "existing_av_status": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}',
-                            "existing_av_status_raw": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}'),
+                            "existing_av_status": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"'
+                                                  ',"mead":"Übermensch"}',
+                            "existing_av_status_raw": _b64e(
+                                '{"result":"pass","ts":"2010-09-08T07:06:04.010101","mead":"Übermensch"}'
+                            ),
                             "unapplied_av_status": AnyJsonEq({
                                 "result": "fail",
                                 "clamdVerStr": "ClamAV 567; first watch",
@@ -1154,7 +1157,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 # expected_notify_calls
                 (),
                 # expected_tagset
-                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}')},
+                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101","mead":"Übermensch"}')},
             ),
             (
                 # initial_tagset

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -1,4 +1,6 @@
+import base64
 import contextlib
+from functools import partial
 from itertools import chain
 import json
 import logging
@@ -101,9 +103,29 @@ def null_context_manager():
     yield
 
 
+def _json_norm_compare(other, x):
+    try:
+        return json.loads(x) == other
+    except ValueError:
+        return False
+
+
 class AnyJsonEq(RestrictedAny):
     def __init__(self, other):
-        super().__init__(lambda x: json.loads(x) == other)
+        super().__init__(partial(_json_norm_compare, other))
+
+
+def _b64_norm_compare(other, x):
+    try:
+        return base64.b64decode(x.encode("ascii")).decode("utf-8") == other
+    except (TypeError, ValueError, UnicodeDecodeError, UnicodeEncodeError):
+        # if it wasn't valid base64 in one way or another, the answer is False
+        return False
+
+
+class AnyB64Eq(RestrictedAny):
+    def __init__(self, other):
+        super().__init__(partial(_b64_norm_compare, other))
 
 
 def _dict_from_tagset(tagset_seq):
@@ -112,6 +134,10 @@ def _dict_from_tagset(tagset_seq):
 
 def _tagset_from_dict(input_dict):
     return [{"Key": k, "Value": v} for k, v in input_dict.items()]
+
+
+def _b64e(value):
+    return base64.b64encode(value.encode("utf-8")).decode("ascii")
 
 
 @pytest.mark.parametrize("cd_string,expected_output", (
@@ -691,7 +717,6 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     (
                         (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus. tag "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "av_status": None,
                             "s3_bucket_name": "spade",
                             "s3_object_key": "sandman/4321-billy-winks.pdf",
                             "s3_object_version": "0",
@@ -749,11 +774,11 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 (),
                 # expected_tagset
                 {
-                    "avStatus": AnyJsonEq({
+                    "avStatus": AnyB64Eq(AnyJsonEq({
                         "result": "pass",
                         "clamdVerStr": "ClamAV 567; first watch",
                         "ts": "2010-09-08T07:06:05.040302",
-                    }),
+                    })),
                     "surprise": "tag234",
                 },
             ),
@@ -786,7 +811,6 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     (
                         (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus. tag "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "av_status": None,
                             "s3_bucket_name": "spade",
                             "s3_object_key": "sandman/4321-billy-winks.pdf",
                             "s3_object_version": "0",
@@ -860,11 +884,11 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 ),
                 # expected_tagset
                 {
-                    "avStatus": AnyJsonEq({
+                    "avStatus": AnyB64Eq(AnyJsonEq({
                         "result": "fail",
                         "clamdVerStr": "ClamAV 567; first watch",
                         "ts": "2010-09-08T07:06:05.040302",
-                    }),
+                    })),
                     "surprise": "tag234",
                 }
             ),
@@ -897,7 +921,6 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     (
                         (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus. tag "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "av_status": None,
                             "s3_bucket_name": "spade",
                             "s3_object_key": "sandman/4321-billy-winks.pdf",
                             "s3_object_version": "0",
@@ -937,7 +960,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 # initial_tagset
                 {"existing": "tag123"},
                 # concurrent_new_tagset
-                {"avStatus": '{"result":"fail","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"fail","ts":"2010-09-08T07:06:04.010101"}')},
                 # clamd_instream_retval
                 {"stream": ("OK", "Egg two demolished",)},
                 # expected_exception
@@ -962,7 +985,6 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     (
                         (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus. tag "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "av_status": None,
                             "s3_bucket_name": "spade",
                             "s3_object_key": "sandman/4321-billy-winks.pdf",
                             "s3_object_version": "0",
@@ -1006,11 +1028,17 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                         ),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "existing_av_status": '{"result":"fail","ts":"2010-09-08T07:06:04.010101"}',
+                            "existing_av_status_raw": _b64e('{"result":"fail","ts":"2010-09-08T07:06:04.010101"}'),
                             "unapplied_av_status": AnyJsonEq({
                                 "result": "pass",
                                 "clamdVerStr": "ClamAV 567; first watch",
                                 "ts": "2010-09-08T07:06:05.040302",
                             }),
+                            "unapplied_av_status_raw": AnyB64Eq(AnyJsonEq({
+                                "result": "pass",
+                                "clamdVerStr": "ClamAV 567; first watch",
+                                "ts": "2010-09-08T07:06:05.040302",
+                            })),
                         })}),
                     ),
                     (
@@ -1026,13 +1054,13 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 # expected_notify_calls
                 (),
                 # expected_tagset
-                {"avStatus": '{"result":"fail","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"fail","ts":"2010-09-08T07:06:04.010101"}')},
             ),
             (
                 # initial_tagset
                 {"existing": "tag123"},
                 # concurrent_new_tagset
-                {"avStatus": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}')},
                 # clamd_instream_retval
                 {"stream": ("FOUND", "After him, boy!",)},
                 # expected_exception
@@ -1057,7 +1085,6 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     (
                         (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus. tag "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "av_status": None,
                             "s3_bucket_name": "spade",
                             "s3_object_key": "sandman/4321-billy-winks.pdf",
                             "s3_object_version": "0",
@@ -1101,11 +1128,17 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                         ),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "existing_av_status": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}',
+                            "existing_av_status_raw": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}'),
                             "unapplied_av_status": AnyJsonEq({
                                 "result": "fail",
                                 "clamdVerStr": "ClamAV 567; first watch",
                                 "ts": "2010-09-08T07:06:05.040302",
                             }),
+                            "unapplied_av_status_raw": AnyB64Eq(AnyJsonEq({
+                                "result": "fail",
+                                "clamdVerStr": "ClamAV 567; first watch",
+                                "ts": "2010-09-08T07:06:05.040302",
+                            })),
                         })}),
                     ),
                     (
@@ -1121,11 +1154,11 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 # expected_notify_calls
                 (),
                 # expected_tagset
-                {"avStatus": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}')},
             ),
             (
                 # initial_tagset
-                {"avStatus": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}')},
                 # concurrent_new_tagset
                 None,
                 # clamd_instream_retval
@@ -1152,7 +1185,8 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     (
                         (logging.INFO, AnyStringMatching(r"Object version.*already.*avStatus.*tag.+"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "av_status": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}',
+                            "existing_av_status": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}',
+                            "existing_av_status_raw": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}'),
                             "s3_bucket_name": "spade",
                             "s3_object_key": "sandman/4321-billy-winks.pdf",
                             "s3_object_version": "0",
@@ -1171,11 +1205,11 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 # expected_notify_calls
                 (),
                 # expected_tagset
-                {"avStatus": '{"result":"pass","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"pass","ts":"2010-09-08T07:06:04.010101"}')},
             ),
             (
                 # initial_tagset
-                {"avStatus": '{"result":"fail","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"fail","ts":"2010-09-08T07:06:04.010101"}')},
                 # concurrent_new_tagset
                 None,
                 # clamd_instream_retval
@@ -1202,7 +1236,8 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     (
                         (logging.INFO, AnyStringMatching(r"Object version.*already.*avStatus.*tag.+"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
-                            "av_status": '{"result":"fail","ts":"2010-09-08T07:06:04.010101"}',
+                            "existing_av_status": '{"result":"fail","ts":"2010-09-08T07:06:04.010101"}',
+                            "existing_av_status_raw": _b64e('{"result":"fail","ts":"2010-09-08T07:06:04.010101"}'),
                             "s3_bucket_name": "spade",
                             "s3_object_key": "sandman/4321-billy-winks.pdf",
                             "s3_object_version": "0",
@@ -1221,7 +1256,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 # expected_notify_calls
                 (),
                 # expected_tagset
-                {"avStatus": '{"result":"fail","ts":"2010-09-08T07:06:04.010101"}'},
+                {"avStatus": _b64e('{"result":"fail","ts":"2010-09-08T07:06:04.010101"}')},
             ),
         ),
     )


### PR DESCRIPTION
We also make `ContentDisposition` handling more lenient & do some tidying here. It sometimes seems a bit silly to fuss over the logging so much especially when it comes to the testing, but as this is unattended and we're unable to spoof being the caller (easily), having the logs and knowing they're right is the only way we can see what's actually going on.