### PR TITLE
 handle_s3_sns: tagging: set separate tags for avStatus instead of a single json blob

### DIFF
--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -433,14 +433,14 @@ def _handle_s3_sns_record(record, message_id):
                     current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
                     template_name_or_id="developer_virus_alert",
                     personalisation={
-                        "region_name": record["awsRegion"],
+                        "region_name": record.get("awsRegion") or "<unknown>",
                         "bucket_name": s3_bucket_name,
                         "object_key": s3_object_key,
                         "object_version": s3_object_version,
-                        "file_name": file_name,
+                        "file_name": file_name or "<unknown>",
                         "clamd_output": ", ".join(clamd_result),
                         "sns_message_id": message_id,
-                        "dm_trace_id": request.trace_id,
+                        "dm_trace_id": request.trace_id or "<unknown>",
                     },
                 )
             except EmailError as e:

--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -299,7 +299,7 @@ def handle_s3_sns():
                     VersionId=s3_object_version,
                 )
 
-            file_name = _filename_from_content_disposition(s3_object["ContentDisposition"] or "")
+            file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
 
             with logged_duration(
                 logger=current_app.logger,

--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -225,228 +225,232 @@ def handle_s3_sns():
         abort(400, f"Message contents didn't match expected format")
 
     for record in records:
+        _handle_s3_sns_record(record, body_dict["MessageId"])
+
+    return jsonify(status="ok", dmTraceId=request.trace_id), 200
+
+
+def _handle_s3_sns_record(record, message_id):
+    with logged_duration(
+        logger=current_app.logger,
+        message=lambda _: (
+            "Handled bucket {s3_bucket_name} key {s3_object_key} version {s3_object_version}"
+            if sys.exc_info()[0] is None else
+            # need to literally format() the exception into message as it's difficult to get it injected into extra
+            "Failed handling {{s3_bucket_name}} key {{s3_object_key}} version {{s3_object_version}}: {!r}".format(
+                sys.exc_info()[1]
+            )
+        ),
+        log_level=logging.INFO,
+        condition=True,
+    ) as log_context:
+        s3_bucket_name = record["s3"]["bucket"]["name"]
+        s3_object_key = record["s3"]["object"]["key"]
+        s3_object_version = record["s3"]["object"]["versionId"]
+        base_log_context = {
+            "s3_bucket_name": s3_bucket_name,
+            "s3_object_key": s3_object_key,
+            "s3_object_version": s3_object_version,
+        }
+        log_context.update(base_log_context)
+
+        # TODO abort if file too big?
+
+        s3_client = boto3.client("s3", region_name=record["awsRegion"])
+
+        with log_external_request(
+            "S3",
+            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            tagging_tag_set = s3_client.get_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )["TagSet"]
+
+        av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
+
+        if av_status.get("avStatus.result") is None:
+            current_app.logger.info(
+                "Object version {s3_object_version} has no 'avStatus.result' tag - will scan...",
+                extra={
+                    **base_log_context,
+                    "av_status": av_status,
+                },
+            )
+        else:
+            current_app.logger.info(
+                "Object version {s3_object_version} already has 'avStatus.result' "
+                "tag: {existing_av_status_result!r}",
+                extra={
+                    **base_log_context,
+                    "existing_av_status_result": av_status["avStatus.result"],
+                    "existing_av_status": av_status,
+                },
+            )
+            return
+
+        clamd_client = get_clamd_socket()
+        # first check our clamd is available - there's no point in going and fetching the object if we can't do
+        # anything with it. allow a raised exception to bubble up as a 500, which seems the most appropriate thing
+        # in this case
+        clamd_client.ping()
+
+        # the following two requests (to S3 for the file contents and to clamd for scanning) don't really happen
+        # sequentially as we're going to attempt to stream the data received from one into the other (by passing
+        # the StreamingBody file-like object from this response into .instream(...)), so these logged_duration
+        # sections do NOT *directly* correspond to the file being downloaded and then the file being scanned. The
+        # two activities will overlap in time, something that isn't expressible with logged_duration
+        with log_external_request(
+            "S3",
+            "initiate object download [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            s3_object = s3_client.get_object(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )
+
+        file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
+
         with logged_duration(
             logger=current_app.logger,
             message=lambda _: (
-                "Handled bucket {s3_bucket_name} key {s3_object_key} version {s3_object_version}"
+                "Scanned {file_length}byte file '{file_name}', result {clamd_result}"
                 if sys.exc_info()[0] is None else
-                # need to literally format() the exception into message as it's difficult to get it injected into extra
-                "Failed handling {{s3_bucket_name}} key {{s3_object_key}} version {{s3_object_version}}: {!r}".format(
+                # need to literally format() exception into message as it's difficult to get it injected into extra
+                "Failed scanning {{file_length}}byte file '{{file_name}}': {!r}".format(
                     sys.exc_info()[1]
                 )
             ),
             log_level=logging.INFO,
             condition=True,
-        ) as log_context:
-            s3_bucket_name = record["s3"]["bucket"]["name"]
-            s3_object_key = record["s3"]["object"]["key"]
-            s3_object_version = record["s3"]["object"]["versionId"]
-            base_log_context = {
-                "s3_bucket_name": s3_bucket_name,
-                "s3_object_key": s3_object_key,
-                "s3_object_version": s3_object_version,
-            }
-            log_context.update(base_log_context)
+        ) as log_context_clamd:
+            log_context_clamd.update({
+                "file_length": s3_object["ContentLength"],
+                "file_name": file_name or "<unknown>",
+            })
+            clamd_result = clamd_client.instream(s3_object["Body"])["stream"]
+            log_context_clamd["clamd_result"] = clamd_result
 
-            # TODO abort if file too big?
+        if clamd_result[0] == "ERROR":
+            # let's hope this was a transient error and a later attempt may succeed. hard to know what else to do
+            # in this case - tagging a file with "ERROR" would prevent further attempts.
+            raise UnknownClamdError(f"clamd did not successfully scan file: {clamd_result!r}")
 
-            s3_client = boto3.client("s3", region_name=record["awsRegion"])
-
-            with log_external_request(
-                "S3",
-                "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                tagging_tag_set = s3_client.get_object_tagging(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                )["TagSet"]
-
-            av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
-
-            if av_status.get("avStatus.result") is None:
-                current_app.logger.info(
-                    "Object version {s3_object_version} has no 'avStatus.result' tag - will scan...",
-                    extra={
-                        **base_log_context,
-                        "av_status": av_status,
-                    },
+        with logged_duration(
+            logger=current_app.logger,
+            message=lambda _: (
+                "Fetched clamd version string: {clamd_version}"
+                if sys.exc_info()[0] is None else
+                # need to literally format() exception into message as it's difficult to get it injected into extra
+                "Failed fetching clamd version string: {!r}".format(
+                    sys.exc_info()[1]
                 )
-            else:
-                current_app.logger.info(
-                    "Object version {s3_object_version} already has 'avStatus.result' "
-                    "tag: {existing_av_status_result!r}",
-                    extra={
-                        **base_log_context,
-                        "existing_av_status_result": av_status["avStatus.result"],
-                        "existing_av_status": av_status,
-                    },
-                )
-                continue
+            ),
+            log_level=logging.DEBUG,
+        ) as log_context_clamd:
+            # hypothetically there is a race condition between the time of scanning the file and fetching the
+            # version here when freshclam could give us a new definition file, making this information incorrect,
+            # but it's a very small possibility
+            clamd_version = clamd_client.version()
+            log_context_clamd.update({"clamd_version": clamd_version})
 
-            clamd_client = get_clamd_socket()
-            # first check our clamd is available - there's no point in going and fetching the object if we can't do
-            # anything with it. allow a raised exception to bubble up as a 500, which seems the most appropriate thing
-            # in this case
-            clamd_client.ping()
+        # we namespace all keys set as part of an avStatus update with an "avStatus." prefix, intending that all
+        # of these keys are only ever set or removed together as they are all information about the same scanning
+        # decision
+        new_av_status = {
+            "avStatus.result": "pass" if clamd_result[0] == "OK" else "fail",
+            "avStatus.clamdVerStr": clamd_version,
+            "avStatus.ts": datetime.datetime.utcnow().isoformat(),
+        }
 
-            # the following two requests (to S3 for the file contents and to clamd for scanning) don't really happen
-            # sequentially as we're going to attempt to stream the data received from one into the other (by passing
-            # the StreamingBody file-like object from this response into .instream(...)), so these logged_duration
-            # sections do NOT *directly* correspond to the file being downloaded and then the file being scanned. The
-            # two activities will overlap in time, something that isn't expressible with logged_duration
-            with log_external_request(
-                "S3",
-                "initiate object download [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                s3_object = s3_client.get_object(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                )
+        # Now we briefly re-check the object's tags to ensure they weren't set by something else while we were
+        # scanning. Note the impossibility of avoiding all possible race conditions as S3's API doesn't allow any
+        # form of locking. What we *can* do is make the possible time period between check-tags and set-tags as
+        # small as possible...
+        with log_external_request(
+            "S3",
+            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            tagging_tag_set = s3_client.get_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )["TagSet"]
 
-            file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
+        av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
 
-            with logged_duration(
-                logger=current_app.logger,
-                message=lambda _: (
-                    "Scanned {file_length}byte file '{file_name}', result {clamd_result}"
-                    if sys.exc_info()[0] is None else
-                    # need to literally format() exception into message as it's difficult to get it injected into extra
-                    "Failed scanning {{file_length}}byte file '{{file_name}}': {!r}".format(
-                        sys.exc_info()[1]
-                    )
-                ),
-                log_level=logging.INFO,
-                condition=True,
-            ) as log_context_clamd:
-                log_context_clamd.update({
-                    "file_length": s3_object["ContentLength"],
-                    "file_name": file_name or "<unknown>",
-                })
-                clamd_result = clamd_client.instream(s3_object["Body"])["stream"]
-                log_context_clamd["clamd_result"] = clamd_result
+        if av_status.get("avStatus.result") is not None:
+            current_app.logger.warning(
+                "Object was tagged with new 'avStatus.result' ({existing_av_status_result!r}) while we were "
+                "scanning. Not applying our own 'avStatus' ({unapplied_av_status_result!r})",
+                extra={
+                    "existing_av_status_result": av_status["avStatus.result"],
+                    "unapplied_av_status_result": new_av_status["avStatus.result"],
+                    "existing_av_status": av_status,
+                    "unapplied_av_status": new_av_status,
+                },
+            )
+            return
 
-            if clamd_result[0] == "ERROR":
-                # let's hope this was a transient error and a later attempt may succeed. hard to know what else to do
-                # in this case - tagging a file with "ERROR" would prevent further attempts.
-                raise UnknownClamdError(f"clamd did not successfully scan file: {clamd_result!r}")
+        tagging_tag_set = _tag_set_updated_with_dict(
+            _tag_set_stripped_of_prefixed(tagging_tag_set, "avStatus."),
+            new_av_status,
+        )
 
-            with logged_duration(
-                logger=current_app.logger,
-                message=lambda _: (
-                    "Fetched clamd version string: {clamd_version}"
-                    if sys.exc_info()[0] is None else
-                    # need to literally format() exception into message as it's difficult to get it injected into extra
-                    "Failed fetching clamd version string: {!r}".format(
-                        sys.exc_info()[1]
-                    )
-                ),
-                log_level=logging.DEBUG,
-            ) as log_context_clamd:
-                # hypothetically there is a race condition between the time of scanning the file and fetching the
-                # version here when freshclam could give us a new definition file, making this information incorrect,
-                # but it's a very small possibility
-                clamd_version = clamd_client.version()
-                log_context_clamd.update({"clamd_version": clamd_version})
-
-            # we namespace all keys set as part of an avStatus update with an "avStatus." prefix, intending that all
-            # of these keys are only ever set or removed together as they are all information about the same scanning
-            # decision
-            new_av_status = {
-                "avStatus.result": "pass" if clamd_result[0] == "OK" else "fail",
-                "avStatus.clamdVerStr": clamd_version,
-                "avStatus.ts": datetime.datetime.utcnow().isoformat(),
-            }
-
-            # Now we briefly re-check the object's tags to ensure they weren't set by something else while we were
-            # scanning. Note the impossibility of avoiding all possible race conditions as S3's API doesn't allow any
-            # form of locking. What we *can* do is make the possible time period between check-tags and set-tags as
-            # small as possible...
-            with log_external_request(
-                "S3",
-                "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                tagging_tag_set = s3_client.get_object_tagging(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                )["TagSet"]
-
-            av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
-
-            if av_status.get("avStatus.result") is not None:
-                current_app.logger.warning(
-                    "Object was tagged with new 'avStatus.result' ({existing_av_status_result!r}) while we were "
-                    "scanning. Not applying our own 'avStatus' ({unapplied_av_status_result!r})",
-                    extra={
-                        "existing_av_status_result": av_status["avStatus.result"],
-                        "unapplied_av_status_result": new_av_status["avStatus.result"],
-                        "existing_av_status": av_status,
-                        "unapplied_av_status": new_av_status,
-                    },
-                )
-                continue
-
-            tagging_tag_set = _tag_set_updated_with_dict(
-                _tag_set_stripped_of_prefixed(tagging_tag_set, "avStatus."),
-                new_av_status,
+        with log_external_request(
+            "S3",
+            "put object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            s3_client.put_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+                Tagging={"TagSet": tagging_tag_set},
             )
 
-            with log_external_request(
-                "S3",
-                "put object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-                logger=current_app.logger,
-            ) as log_context_s3:
-                log_context_s3.update(base_log_context)
-                s3_client.put_object_tagging(
-                    Bucket=s3_bucket_name,
-                    Key=s3_object_key,
-                    VersionId=s3_object_version,
-                    Tagging={"TagSet": tagging_tag_set},
+        if clamd_result[0] != "OK":
+            # TODO? attempt to rectify the situation:
+            # TODO? if this is (still) current version of object:
+            # TODO?     S3: find most recent version of object which is tagged "good"
+            # TODO?     if there is no such version:
+            # TODO?         S3: upload fail whale?
+            # TODO?     else copy that version to become new "current" ver for this key, ensuring to copy its tags
+            # TODO?         note the impossibility of doing this without some race conditions
+
+            notify_client = DMNotifyClient(current_app.config["DM_NOTIFY_API_KEY"])
+            try:
+                notify_client.send_email(
+                    current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
+                    template_name_or_id="developer_virus_alert",
+                    personalisation={
+                        "region_name": record["awsRegion"],
+                        "bucket_name": s3_bucket_name,
+                        "object_key": s3_object_key,
+                        "object_version": s3_object_version,
+                        "file_name": file_name,
+                        "clamd_output": ", ".join(clamd_result),
+                        "sns_message_id": message_id,
+                        "dm_trace_id": request.trace_id,
+                    },
                 )
-
-            if clamd_result[0] != "OK":
-                # TODO? attempt to rectify the situation:
-                # TODO? if this is (still) current version of object:
-                # TODO?     S3: find most recent version of object which is tagged "good"
-                # TODO?     if there is no such version:
-                # TODO?         S3: upload fail whale?
-                # TODO?     else copy that version to become new "current" ver for this key, ensuring to copy its tags
-                # TODO?         note the impossibility of doing this without some race conditions
-
-                notify_client = DMNotifyClient(current_app.config["DM_NOTIFY_API_KEY"])
-                try:
-                    notify_client.send_email(
-                        current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
-                        template_name_or_id="developer_virus_alert",
-                        personalisation={
-                            "region_name": record["awsRegion"],
-                            "bucket_name": s3_bucket_name,
-                            "object_key": s3_object_key,
-                            "object_version": s3_object_version,
-                            "file_name": file_name,
-                            "clamd_output": ", ".join(clamd_result),
-                            "sns_message_id": body_dict["MessageId"],
-                            "dm_trace_id": request.trace_id,
-                        },
-                    )
-                except EmailError as e:
-                    current_app.logger.error(
-                        "Failed to send developer_virus_alert email after scanning "
-                        "{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}: {e}",
-                        extra={
-                            **base_log_context,
-                            "e": str(e),
-                        },
-                    )
-                    # however we still want this request to return a successful status to signify to SNS that it
-                    # should not attempt to re-send this message
-
-    return jsonify(status="ok", dmTraceId=request.trace_id), 200
+            except EmailError as e:
+                current_app.logger.error(
+                    "Failed to send developer_virus_alert email after scanning "
+                    "{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}: {e}",
+                    extra={
+                        **base_log_context,
+                        "e": str(e),
+                    },
+                )
+                # however we still want this request to return a successful status to signify to SNS that it
+                # should not attempt to re-send this message

--- a/config.py
+++ b/config.py
@@ -20,6 +20,8 @@ class Config:
 
     DM_CLAMD_UNIX_SOCKET_PATH = "/var/run/clamav/clamd.ctl"
 
+    DM_NOTIFY_API_KEY = None
+
     DM_DEVELOPER_VIRUS_ALERT_EMAIL = "developer-virus-alert@example.com"
     NOTIFY_TEMPLATES = {
         "developer_virus_alert": "70986093-4f54-4b2e-883e-d88456455385",


### PR DESCRIPTION
On the advice of @lfdebrux it would probably be useful for these `avStatus` result tags we're adding to be less opaque than json/base64 would make them. We might want to be able to make other tools act upon their values, and this is harder to do if those tools would first have to be able to decode our special blobs. For instance, it would stop us being able to e.g. set up permissions based on tag values.

With a view to fixing this, this PR, probably replacing https://github.com/alphagov/digitalmarketplace-antivirus-api/pull/12, separates the "metadata" out into separate tags. There is an added danger here that the message is lost among us that the `avStatus.*` key(s) are only ever supposed to be set *together* and never one on its own - always all referring to a single scanning event, leading to us gaining mismatching data in these tags. Even so it's probably more advantageous to have more generally accessible tag values.