### PR TITLE
handle_s3_sns: add special handling of case when only the eicar test file is found

### DIFF
--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -158,7 +158,7 @@ def _prefixed_tag_values_from_tag_set(tag_set, prefix):
     return {tag["Key"]: tag["Value"] for tag in tag_set if tag["Key"].startswith(prefix)}
 
 
-def _tag_set_stripped_of_prefixed(tag_set, prefix):
+def _tag_set_omitting_prefixed(tag_set, prefix):
     return [tag for tag in tag_set if not tag["Key"].startswith(prefix)]
 
 
@@ -408,7 +408,7 @@ def _handle_s3_sns_record(record, message_id):
             return
 
         tagging_tag_set = _tag_set_updated_with_dict(
-            _tag_set_stripped_of_prefixed(tagging_tag_set, "avStatus."),
+            _tag_set_omitting_prefixed(tagging_tag_set, "avStatus."),
             new_av_status,
         )
 

--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -445,7 +445,10 @@ def _handle_s3_sns_record(record, message_id):
                     # that will be shared knowledge between a functional test and the application yet also allow the
                     # test to differentiate the results of its different test runs, allowing it to easily check for
                     # the message being sent
-                    "reference": "eicar-found-{}".format(_normalize_hex(s3_object["ETag"])),
+                    "reference": "eicar-found-{}-{}".format(
+                        _normalize_hex(s3_object["ETag"]),
+                        current_app.config["DM_ENVIRONMENT"],
+                    ),
                     "to_email_address": current_app.config["DM_EICAR_TEST_SIGNATURE_VIRUS_ALERT_EMAIL"],
                 }
             else:

--- a/config.py
+++ b/config.py
@@ -22,6 +22,8 @@ class Config:
 
     DM_NOTIFY_API_KEY = None
 
+    DM_EICAR_TEST_SIGNATURE_RESULT_STRING = "Eicar-Test-Signature"
+    DM_EICAR_TEST_SIGNATURE_VIRUS_ALERT_EMAIL = "eicar-found@example.gov.uk"
     DM_DEVELOPER_VIRUS_ALERT_EMAIL = "developer-virus-alert@example.com"
     NOTIFY_TEMPLATES = {
         "developer_virus_alert": "70986093-4f54-4b2e-883e-d88456455385",

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -966,7 +966,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                             "sns_message_id": "424344def",
                         },
                         template_name_or_id="developer_virus_alert",
-                        reference="eicar-found-4d3daeeb3ea3d90d4d6e7a20a5b483a9",
+                        reference="eicar-found-4d3daeeb3ea3d90d4d6e7a20a5b483a9-development",
                     ),
                 ),
                 # expected_tagset

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -845,7 +845,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                 (
                     mock.call("not_a_real_key-00000000-fake-uuid-0000-000000000000"),
                     mock.call().send_email(
-                        "developer-virus-alert@example.com",
+                        to_email_address="developer-virus-alert@example.com",
                         personalisation={
                             "bucket_name": "spade",
                             "clamd_output": "FOUND, After him, Garry!",
@@ -865,6 +865,116 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                     "avStatus.clamdVerStr": "ClamAV 567_ first watch",
                     "avStatus.ts": "2010-09-08T07:06:05.040302",
                     "surprise": "tag234",
+                }
+            ),
+            (
+                # initial_tagset
+                {"existing": "tag123"},
+                # concurrent_new_tagset
+                None,
+                # clamd_instream_retval
+                {"stream": ("FOUND", "eicar-test-signature",)},
+                # expected_exception
+                None,
+                # expected_log_calls
+                (
+                    (
+                        (logging.INFO, AnyStringMatching(r"Processing message "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "message_id": "424344def",
+                            "subscription_arn": "bull:by:the:horns:123:s3_file_upload_notification_development:314159",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus\.result. tag "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "av_status": {},
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Scanned "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "file_length": 12,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "clamd_result": ("FOUND", "eicar-test-signature"),
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Fetched clamd version "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "clamd_version": "ClamAV 567; first watch",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(put object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (mock.ANY, AnySupersetOf({"extra": AnySupersetOf({"status": 200})})),
+                ),
+                # expected_notify_calls
+                (
+                    mock.call("not_a_real_key-00000000-fake-uuid-0000-000000000000"),
+                    mock.call().send_email(
+                        to_email_address="eicar-found@example.gov.uk",
+                        personalisation={
+                            "bucket_name": "spade",
+                            "clamd_output": "FOUND, eicar-test-signature",
+                            "dm_trace_id": mock.ANY,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "object_key": "sandman/4321-billy-winks.pdf",
+                            "object_version": "0",
+                            "region_name": "howth-west-2",
+                            "sns_message_id": "424344def",
+                        },
+                        template_name_or_id="developer_virus_alert",
+                        reference="eicar-found-4d3daeeb3ea3d90d4d6e7a20a5b483a9",
+                    ),
+                ),
+                # expected_tagset
+                {
+                    "avStatus.result": "fail",
+                    "avStatus.clamdVerStr": "ClamAV 567_ first watch",
+                    "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    "existing": "tag123",
                 }
             ),
             (


### PR DESCRIPTION
Trello https://trello.com/c/RVmfbGgE/384-virus-scanning-functional-tests

This is to allow us to build functional tests with predictable outputs and run them without setting off false alarms. We do this by basing the notify "reference" on the bucket object's `ETag` (which in normal cases should be the file's md5) and by making sure alerts about such files are always "sent to" a specific dummy address.