### PR TITLE
Restrict callbacks endpoints to Amazon IP ranges

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@
 !config.py
 !requirements.txt
 !config/
+!scripts/
+!templates/

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,3 +36,9 @@ RUN cat /home/vcap/additional-supervisord.conf >> /etc/supervisord.conf
 
 COPY config/additional-awslogs.conf /home/vcap/additional-awslogs.conf
 RUN cat /home/vcap/additional-awslogs.conf >> /etc/awslogs.conf
+
+COPY scripts/inject-sns-ips-into-nginx-api-conf.py /usr/local/sbin/inject-sns-ips-into-nginx-api-conf.py
+COPY templates/api.j2 /etc/nginx/templates/api.j2
+COPY config/logrotate.conf /etc/logrotate.d/amazon_ip_update
+RUN echo "@reboot . /app/venv/bin/activate && /usr/local/sbin/inject-sns-ips-into-nginx-api-conf.py" | crontab -
+RUN (crontab -l && echo "*/5 * * * * . /app/venv/bin/activate && /usr/local/sbin/inject-sns-ips-into-nginx-api-conf.py") | crontab -

--- a/config/additional-awslogs.conf
+++ b/config/additional-awslogs.conf
@@ -11,7 +11,7 @@ log_group_name = {DM_ENVIRONMENT}-{DM_APP_NAME}-freshclam
 log_stream_name = {hostname}
 datetime_format = %d/%b/%Y:%H:%M:%S %z
 
-[antiviris-amazon-ip-update-logs]
+[antivirus-amazon-ip-update-logs]
 file = /var/log/amazon_ip_update.log
 log_group_name = {DM_ENVIRONMENT}-{DM_APP_NAME}-amazon-ip-update
 log_stream_name = {hostname}

--- a/config/additional-awslogs.conf
+++ b/config/additional-awslogs.conf
@@ -10,3 +10,9 @@ file = /var/log/clamav/freshclam.log
 log_group_name = {DM_ENVIRONMENT}-{DM_APP_NAME}-freshclam
 log_stream_name = {hostname}
 datetime_format = %d/%b/%Y:%H:%M:%S %z
+
+[antiviris-amazon-ip-update-logs]
+file = /var/log/amazon_ip_update.log
+log_group_name = {DM_ENVIRONMENT}-{DM_APP_NAME}-amazon-ip-update
+log_stream_name = {hostname}
+datetime_format = %d/%b/%Y:%H:%M:%S %z

--- a/config/additional-supervisord.conf
+++ b/config/additional-supervisord.conf
@@ -19,3 +19,14 @@ stderr_logfile = /var/log/clamd.log
 stderr_logfile_maxbytes = 5000000
 stderr_logfile_backups = 3
 stopsignal = INT
+
+[program:cron]
+command = cron -f
+priority = 1000
+autostart = true
+autorestart = false
+stdout_logfile = /dev/stdout
+stdout_logfile_maxbytes = 0
+stderr_logfile = /var/log/cron.err.log
+stderr_logfile_maxbytes = 5000000
+stderr_logfile_backups = 3

--- a/config/logrotate.conf
+++ b/config/logrotate.conf
@@ -1,0 +1,7 @@
+/var/log/amazon_ip_update.log {
+  rotate 3
+  size 5M
+  compress
+  missingok
+  notifempty
+}

--- a/scripts/inject-sns-ips-into-nginx-api-conf.py
+++ b/scripts/inject-sns-ips-into-nginx-api-conf.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python
+import logging
+import subprocess
+import sys
+
+import jinja2
+from jinja2.runtime import StrictUndefined
+import requests
+
+logger = logging.getLogger("antivirus-api-callback-ip-update")
+
+
+def get_filtered_ip_ranges():
+    try:
+        response = requests.get('https://ip-ranges.amazonaws.com/ip-ranges.json')
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error(f"Error: failed to get IP ranges - {e}")
+        sys.exit(1)
+
+    all_ip_ranges = response.json()['prefixes']
+
+    # Currently AWS does not provide specific IP ranges for the SNS service. They will in future though.
+    filtered_ip_ranges = [
+        i['ip_prefix'] for i in all_ip_ranges if i['service'] == 'AMAZON' and i['region'] == 'eu-west-1'
+    ]
+
+    if not filtered_ip_ranges:
+        print("No IP ranges found after filtering")
+        sys.exit(1)
+
+    return filtered_ip_ranges
+
+
+def template_conf(sns_ip_ranges):
+    jinja_env = jinja2.Environment(
+        trim_blocks=True,
+        loader=jinja2.FileSystemLoader('/etc/nginx/templates'),
+        undefined=StrictUndefined,
+    )
+
+    template = jinja_env.get_template('api.j2')
+    template.stream(sns_ips=sns_ip_ranges).dump('/etc/nginx/sites-enabled/api')
+
+
+def reload_nginx():
+    try:
+        subprocess.run(["/usr/sbin/nginx", "-s", "reload"], check=True)
+        logger.info("SNS IP whitelist updated")
+    except subprocess.CalledProcessError as e:
+        logger.error("Error: failed to reload nginx")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s:%(name)s:%(levelname)s:%(message)s",
+        handlers=[
+            logging.FileHandler('/var/log/amazon_ip_update.log'),
+            logging.StreamHandler(),
+        ]
+    )
+
+    template_conf(sns_ip_ranges=get_filtered_ip_ranges())
+    reload_nginx()

--- a/templates/api.j2
+++ b/templates/api.j2
@@ -2,6 +2,13 @@ server {
     listen 80;
 
     location /callbacks {
+      # Replace proxy IPs with real user IP
+      real_ip_header X-Forwarded-For;
+      set_real_ip_from 10.0.0.0/16;
+      set_real_ip_from 127.0.0.1/32;
+      real_ip_recursive on;
+
+      # Allow only IP addresses associated with AWS
       {% for sns_ip in sns_ips %}
         allow {{ sns_ip }};
       {% endfor %}

--- a/templates/api.j2
+++ b/templates/api.j2
@@ -1,0 +1,18 @@
+server {
+    listen 80;
+
+    location /callbacks {
+      {% for sns_ip in sns_ips %}
+        allow {{ sns_ip }};
+      {% endfor %}
+        deny all;
+
+        include uwsgi_params;
+        uwsgi_pass unix:///run/uwsgi.sock;
+    }
+
+    location / {
+        include uwsgi_params;
+        uwsgi_pass unix:///run/uwsgi.sock;
+    }
+}


### PR DESCRIPTION
For [this trello ticket](https://trello.com/c/irK1fzZR).

Fair warning, this might be a terrible approach.

The callbacks endpoint should only ever be called by Amazon SNS. Amazon
publishes their IP ranges; they're obtainable from an endpoint.
Unfortunately they don't _yet_ specify exactly which ranges SNS uses like they
do for some other services, but they say they will be improving this in
future. We're adding all AWS IP ranges for eu-west-1 to ensure we
cover SNS.

These are added by a python script which templates a simple nginx
template. This template is based on the one provided by our docker base
image. The script actually overwrites it. Once templated, the script
reloads nginx to ensure the change is taken into effect.

The script is run every 5 minutes by cron. There are two cron jobs
added in the Dockerfile, one that runs periodically and one that runs on reboot/when cron
is started. This ensures we have the most up to date ip ranges
immediately. AWS state that they may change multiple times per week.

Cron isn't started by default, so we start it with supervisord in the
same way we manage other processes. Supervisord requires that
processes are not demonised, hence why cron is started in the
foreground. Cron has `priority = 1000` in supervisord. Programs with
a lower priority are started first / shutdown last. We haven't used this
property elsewhere but the default is 999. It's set to 1000 here to make
sure that cron is started after nginx. This is so the script can restart
nginx without worrying about if it's already started.

The script logs to file, to allow for any issues to be caught. The file
has been added to the AWS logs agent, and shipped to cloudwatch. This
will allow for an alert or some sort of monitoring to be set up, so we
know if the ip ranges are not being set/updated for any reason.

As we're logging to file, we need to rotate the logfile. As the script
itself isn't being managed by supervisord, we can't use its inbuilt
log rotation. Luckily we have logrotate. So there's a small conf file for
that to ensure that the logfiles from the script never get out of hand.