### PR TITLE
add endpoint for manually triggering scan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+before_install:
+  - export BOTO_CONFIG=/dev/null
 install:
   - make requirements-dev
 script:

--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -1,24 +1,19 @@
 import datetime
 from functools import lru_cache
-from itertools import chain
 import json
 import logging
-import re
 import sys
 
-import boto3
 from flask import abort, jsonify, current_app, request
 from lxml.etree import fromstring as etree_fromstring, ParseError
 import requests
 
 import validatesns
 
-from dmutils.email.dm_notify import DMNotifyClient
-from dmutils.email.exceptions import EmailError
-from dmutils.timing import logged_duration_for_external_request as log_external_request, logged_duration
+from dmutils.timing import logged_duration
 
 from app.callbacks import callbacks
-from app.clam import get_clamd_socket
+from app.s3 import scan_s3_object
 
 
 @callbacks.route('/')
@@ -144,46 +139,6 @@ VALIDATION_CERTIFICATE_URL_REGEX = r"^https://[-a-z0-9.]+\.amazonaws\.com/"
 VALIDATION_MAX_AGE = datetime.timedelta(hours=1, minutes=1)
 
 
-_filename_re = re.compile(r'^\s*filename=("?)(.+?)\1\s*$')
-
-
-def _filename_from_content_disposition(content_disposition):
-    return next(
-        (match.group(2) for match in (_filename_re.match(sect) for sect in content_disposition.split(";")) if match),
-        None,
-    )
-
-
-def _prefixed_tag_values_from_tag_set(tag_set, prefix):
-    return {tag["Key"]: tag["Value"] for tag in tag_set if tag["Key"].startswith(prefix)}
-
-
-def _tag_set_omitting_prefixed(tag_set, prefix):
-    return [tag for tag in tag_set if not tag["Key"].startswith(prefix)]
-
-
-# See https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html
-_invalid_tag_chars_re = re.compile(r"[^-+=.:/\w\s]", flags=re.ASCII)
-
-
-def _tag_set_updated_with_dict(tag_set, update_dict):
-    return list(chain(
-        (kv for kv in tag_set if kv["Key"] not in update_dict),
-        ({"Key": k, "Value": _invalid_tag_chars_re.sub("_", v)} for k, v in update_dict.items()),
-    ))
-
-
-_nonhex_re = re.compile("[^0-9a-f]")
-
-
-def _normalize_hex(value):
-    return _nonhex_re.sub("", value.lower())
-
-
-class UnknownClamdError(Exception):
-    pass
-
-
 @callbacks.route("/sns/s3/uploaded", methods=['POST'])
 def handle_s3_sns():
     body_dict = _get_request_body_json()
@@ -232,253 +187,12 @@ def handle_s3_sns():
         abort(400, f"Message contents didn't match expected format")
 
     for record in records:
-        _handle_s3_sns_record(record, body_dict["MessageId"])
-
-    return jsonify(status="ok", dmTraceId=request.trace_id), 200
-
-
-def _handle_s3_sns_record(record, message_id):
-    with logged_duration(
-        logger=current_app.logger,
-        message=lambda _: (
-            "Handled bucket {s3_bucket_name} key {s3_object_key} version {s3_object_version}"
-            if sys.exc_info()[0] is None else
-            # need to literally format() the exception into message as it's difficult to get it injected into extra
-            "Failed handling {{s3_bucket_name}} key {{s3_object_key}} version {{s3_object_version}}: {!r}".format(
-                sys.exc_info()[1]
-            )
-        ),
-        log_level=logging.INFO,
-        condition=True,
-    ) as log_context:
-        s3_bucket_name = record["s3"]["bucket"]["name"]
-        s3_object_key = record["s3"]["object"]["key"]
-        s3_object_version = record["s3"]["object"]["versionId"]
-        base_log_context = {
-            "s3_bucket_name": s3_bucket_name,
-            "s3_object_key": s3_object_key,
-            "s3_object_version": s3_object_version,
-        }
-        log_context.update(base_log_context)
-
-        # TODO abort if file too big?
-
-        s3_client = boto3.client("s3", region_name=record["awsRegion"])
-
-        with log_external_request(
-            "S3",
-            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-            logger=current_app.logger,
-        ) as log_context_s3:
-            log_context_s3.update(base_log_context)
-            tagging_tag_set = s3_client.get_object_tagging(
-                Bucket=s3_bucket_name,
-                Key=s3_object_key,
-                VersionId=s3_object_version,
-            )["TagSet"]
-
-        av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
-
-        if av_status.get("avStatus.result") is None:
-            current_app.logger.info(
-                "Object version {s3_object_version} has no 'avStatus.result' tag - will scan...",
-                extra={
-                    **base_log_context,
-                    "av_status": av_status,
-                },
-            )
-        else:
-            current_app.logger.info(
-                "Object version {s3_object_version} already has 'avStatus.result' "
-                "tag: {existing_av_status_result!r}",
-                extra={
-                    **base_log_context,
-                    "existing_av_status_result": av_status["avStatus.result"],
-                    "existing_av_status": av_status,
-                },
-            )
-            return
-
-        clamd_client = get_clamd_socket()
-        # first check our clamd is available - there's no point in going and fetching the object if we can't do
-        # anything with it. allow a raised exception to bubble up as a 500, which seems the most appropriate thing
-        # in this case
-        clamd_client.ping()
-
-        # the following two requests (to S3 for the file contents and to clamd for scanning) don't really happen
-        # sequentially as we're going to attempt to stream the data received from one into the other (by passing
-        # the StreamingBody file-like object from this response into .instream(...)), so these logged_duration
-        # sections do NOT *directly* correspond to the file being downloaded and then the file being scanned. The
-        # two activities will overlap in time, something that isn't expressible with logged_duration
-        with log_external_request(
-            "S3",
-            "initiate object download [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-            logger=current_app.logger,
-        ) as log_context_s3:
-            log_context_s3.update(base_log_context)
-            s3_object = s3_client.get_object(
-                Bucket=s3_bucket_name,
-                Key=s3_object_key,
-                VersionId=s3_object_version,
-            )
-
-        file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
-
-        with logged_duration(
-            logger=current_app.logger,
-            message=lambda _: (
-                "Scanned {file_length}byte file '{file_name}', result {clamd_result}"
-                if sys.exc_info()[0] is None else
-                # need to literally format() exception into message as it's difficult to get it injected into extra
-                "Failed scanning {{file_length}}byte file '{{file_name}}': {!r}".format(
-                    sys.exc_info()[1]
-                )
-            ),
-            log_level=logging.INFO,
-            condition=True,
-        ) as log_context_clamd:
-            log_context_clamd.update({
-                "file_length": s3_object["ContentLength"],
-                "file_name": file_name or "<unknown>",
-            })
-            clamd_result = clamd_client.instream(s3_object["Body"])["stream"]
-            log_context_clamd["clamd_result"] = clamd_result
-
-        if clamd_result[0] == "ERROR":
-            # let's hope this was a transient error and a later attempt may succeed. hard to know what else to do
-            # in this case - tagging a file with "ERROR" would prevent further attempts.
-            raise UnknownClamdError(f"clamd did not successfully scan file: {clamd_result!r}")
-
-        with logged_duration(
-            logger=current_app.logger,
-            message=lambda _: (
-                "Fetched clamd version string: {clamd_version}"
-                if sys.exc_info()[0] is None else
-                # need to literally format() exception into message as it's difficult to get it injected into extra
-                "Failed fetching clamd version string: {!r}".format(
-                    sys.exc_info()[1]
-                )
-            ),
-            log_level=logging.DEBUG,
-        ) as log_context_clamd:
-            # hypothetically there is a race condition between the time of scanning the file and fetching the
-            # version here when freshclam could give us a new definition file, making this information incorrect,
-            # but it's a very small possibility
-            clamd_version = clamd_client.version()
-            log_context_clamd.update({"clamd_version": clamd_version})
-
-        # we namespace all keys set as part of an avStatus update with an "avStatus." prefix, intending that all
-        # of these keys are only ever set or removed together as they are all information about the same scanning
-        # decision
-        new_av_status = {
-            "avStatus.result": "pass" if clamd_result[0] == "OK" else "fail",
-            "avStatus.clamdVerStr": clamd_version,
-            "avStatus.ts": datetime.datetime.utcnow().isoformat(),
-        }
-
-        # Now we briefly re-check the object's tags to ensure they weren't set by something else while we were
-        # scanning. Note the impossibility of avoiding all possible race conditions as S3's API doesn't allow any
-        # form of locking. What we *can* do is make the possible time period between check-tags and set-tags as
-        # small as possible...
-        with log_external_request(
-            "S3",
-            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-            logger=current_app.logger,
-        ) as log_context_s3:
-            log_context_s3.update(base_log_context)
-            tagging_tag_set = s3_client.get_object_tagging(
-                Bucket=s3_bucket_name,
-                Key=s3_object_key,
-                VersionId=s3_object_version,
-            )["TagSet"]
-
-        av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
-
-        if av_status.get("avStatus.result") is not None:
-            current_app.logger.warning(
-                "Object was tagged with new 'avStatus.result' ({existing_av_status_result!r}) while we were "
-                "scanning. Not applying our own 'avStatus' ({unapplied_av_status_result!r})",
-                extra={
-                    "existing_av_status_result": av_status["avStatus.result"],
-                    "unapplied_av_status_result": new_av_status["avStatus.result"],
-                    "existing_av_status": av_status,
-                    "unapplied_av_status": new_av_status,
-                },
-            )
-            return
-
-        tagging_tag_set = _tag_set_updated_with_dict(
-            _tag_set_omitting_prefixed(tagging_tag_set, "avStatus."),
-            new_av_status,
+        scan_s3_object(
+            aws_region=record["awsRegion"],
+            s3_bucket_name=record["s3"]["bucket"]["name"],
+            s3_object_key=record["s3"]["object"]["key"],
+            s3_object_version=record["s3"]["object"]["versionId"],
+            sns_message_id=body_dict["MessageId"],
         )
 
-        with log_external_request(
-            "S3",
-            "put object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
-            logger=current_app.logger,
-        ) as log_context_s3:
-            log_context_s3.update(base_log_context)
-            s3_client.put_object_tagging(
-                Bucket=s3_bucket_name,
-                Key=s3_object_key,
-                VersionId=s3_object_version,
-                Tagging={"TagSet": tagging_tag_set},
-            )
-
-        if clamd_result[0] != "OK":
-            # TODO? attempt to rectify the situation:
-            # TODO? if this is (still) current version of object:
-            # TODO?     S3: find most recent version of object which is tagged "good"
-            # TODO?     if there is no such version:
-            # TODO?         S3: upload fail whale?
-            # TODO?     else copy that version to become new "current" ver for this key, ensuring to copy its tags
-            # TODO?         note the impossibility of doing this without some race conditions
-
-            notify_client = DMNotifyClient(current_app.config["DM_NOTIFY_API_KEY"])
-
-            if (
-                len(clamd_result) >= 2 and
-                clamd_result[1].lower() == current_app.config["DM_EICAR_TEST_SIGNATURE_RESULT_STRING"].lower()
-            ):
-                notify_kwargs = {
-                    # we'll use the s3 ETag of the file as the notify ref - it will be the only piece of information
-                    # that will be shared knowledge between a functional test and the application yet also allow the
-                    # test to differentiate the results of its different test runs, allowing it to easily check for
-                    # the message being sent
-                    "reference": "eicar-found-{}-{}".format(
-                        _normalize_hex(s3_object["ETag"]),
-                        current_app.config["DM_ENVIRONMENT"],
-                    ),
-                    "to_email_address": current_app.config["DM_EICAR_TEST_SIGNATURE_VIRUS_ALERT_EMAIL"],
-                }
-            else:
-                notify_kwargs = {
-                    "to_email_address": current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
-                }
-
-            try:
-                notify_client.send_email(
-                    template_name_or_id="developer_virus_alert",
-                    personalisation={
-                        "region_name": record.get("awsRegion") or "<unknown>",
-                        "bucket_name": s3_bucket_name,
-                        "object_key": s3_object_key,
-                        "object_version": s3_object_version,
-                        "file_name": file_name or "<unknown>",
-                        "clamd_output": ", ".join(clamd_result),
-                        "sns_message_id": message_id,
-                        "dm_trace_id": getattr(request, "trace_id", None) or "<unknown>",
-                    },
-                    **notify_kwargs,
-                )
-            except EmailError as e:
-                current_app.logger.error(
-                    "Failed to send developer_virus_alert email after scanning "
-                    "{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}: {e}",
-                    extra={
-                        **base_log_context,
-                        "e": str(e),
-                    },
-                )
-                # however we still want this request to return a successful status to signify to SNS that it
-                # should not attempt to re-send this message
+    return jsonify(status="ok", dmTraceId=request.trace_id), 200

--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -195,4 +195,4 @@ def handle_s3_sns():
             sns_message_id=body_dict["MessageId"],
         )
 
-    return jsonify(status="ok", dmTraceId=request.trace_id), 200
+    return jsonify(status="ok"), 200

--- a/app/clam.py
+++ b/app/clam.py
@@ -13,3 +13,7 @@ def _get_clamd_socket_inner():
 
 def get_clamd_socket():
     return _get_clamd_socket_inner()
+
+
+class UnknownClamdError(Exception):
+    pass

--- a/app/decorators.py
+++ b/app/decorators.py
@@ -1,0 +1,37 @@
+from collections.abc import Mapping
+from functools import wraps
+
+from flask import abort, request
+
+
+def json_payload_view(acceptable_content_types=("application/json",)):
+    def _decorator(func):
+        @wraps(func)
+        def _inner(*args, **kwargs):
+            if request.content_type.split(";")[0] not in acceptable_content_types:
+                abort(400, f"Unexpected Content-Type: expecting one of {sorted(acceptable_content_types)}")
+
+            # using force= parameter because we've already performed the content-type checking
+            body_dict = request.get_json(force=True)
+
+            if not isinstance(body_dict, Mapping):
+                abort(400, "Expected content to be JSON object")
+
+            return func(*args, **kwargs, body_dict=body_dict)
+        return _inner
+
+    return _decorator
+
+
+def require_json_keys(keys):
+    def _decorator(func):
+        @wraps(func)
+        def _inner(*args, body_dict, **kwargs):
+            missing_keys = frozenset(keys) - body_dict.keys()
+            if missing_keys:
+                abort(400, f"Expected top-level JSON keys: {sorted(missing_keys)}")
+            return func(*args, **kwargs, body_dict=body_dict)
+
+        return _inner
+
+    return _decorator

--- a/app/main/views/scan.py
+++ b/app/main/views/scan.py
@@ -83,7 +83,10 @@ def scan_s3_object(body_dict):
     )
 
     return jsonify(
+        # any avStatus.* tags the object already had or were added while we were busy scanning
         existingAvStatus=old_av_status,
+        # the newly-calculated avStatus, if scanning was performed
         newAvStatus=new_av_status,
+        # whether the new avStatus was actually applied to the s3 object tags
         avStatusApplied=applied,
     ), 200

--- a/app/main/views/scan.py
+++ b/app/main/views/scan.py
@@ -1,16 +1,19 @@
 from io import BytesIO
 
+import boto3
 import clamd
 from flask import abort, jsonify, request, current_app
 
-from dmutils.timing import logged_duration_for_external_request
+from dmutils.timing import logged_duration_for_external_request as log_external_request
 
-from app.main import main
 from app.clam import get_clamd_socket
+from app.decorators import json_payload_view, require_json_keys
+from app.main import main
+from app.s3 import scan_and_tag_s3_object
 
 
-@main.route('/scan', methods=['POST'])
-def scan():
+@main.route('/scan/direct', methods=['POST'])
+def scan_direct():
     if 'document' not in request.files:
         abort(400, 'The file for scanning should be uploaded under the name `document`.')
 
@@ -19,7 +22,7 @@ def scan():
     try:
         client = get_clamd_socket()
 
-        with logged_duration_for_external_request(service='ClamAV', description='instream scan via unix socket'):
+        with log_external_request(service='ClamAV', description='instream scan via unix socket'):
             scan_result = client.instream(BytesIO(file.stream.read()))['stream']
 
     except clamd.ClamdError as e:
@@ -32,3 +35,55 @@ def scan():
     }
 
     return jsonify(response_json), 200
+
+
+@main.route('/scan/s3-object', methods=['POST'])
+@json_payload_view()
+@require_json_keys(("bucketName", "objectKey", "objectVersionId",))
+def scan_s3_object(body_dict):
+    s3_client = boto3.client("s3", region_name=current_app.config["DM_DEFAULT_AWS_REGION"])
+
+    # it's easier to pre-check the existence of the s3 object and generate error messages from the results than to
+    # attempt to catch & interpret various errors bubbling up from scan_and_tag_s3_object when we run into them there
+    try:
+        with log_external_request(
+            "S3",
+            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update({
+                "s3_bucket_name": body_dict["bucketName"],
+                "s3_object_key": body_dict["objectKey"],
+                "s3_object_version": body_dict["objectVersionId"],
+            })
+            s3_client.head_object(
+                Bucket=body_dict["bucketName"],
+                Key=body_dict["objectKey"],
+                VersionId=body_dict["objectVersionId"],
+            )
+    except s3_client.exceptions.NoSuchBucket:
+        abort(400, f"Bucket {body_dict['bucketName']!r} not found")
+    except s3_client.exceptions.ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "404":
+            # it doesn't appear to be easily discernable whether a 404 is due to a missing version id or missing key
+            # altogether, so an all-in-one error message
+            abort(
+                400,
+                f"Object with key {body_dict['objectKey']!r} and version {body_dict['objectVersionId']!r} not found in "
+                f"bucket {body_dict['bucketName']!r}",
+            )
+        # unexpected ClientError, we should probably know about this so re-raise
+        raise
+
+    old_av_status, applied, new_av_status = scan_and_tag_s3_object(
+        s3_client=s3_client,
+        s3_bucket_name=body_dict["bucketName"],
+        s3_object_key=body_dict["objectKey"],
+        s3_object_version=body_dict["objectVersionId"],
+    )
+
+    return jsonify(
+        existingAvStatus=old_av_status,
+        newAvStatus=new_av_status,
+        avStatusApplied=applied,
+    ), 200

--- a/app/s3.py
+++ b/app/s3.py
@@ -1,0 +1,301 @@
+import datetime
+from itertools import chain
+import logging
+import re
+import sys
+
+import boto3
+from flask import current_app, request
+
+from dmutils.email.dm_notify import DMNotifyClient
+from dmutils.email.exceptions import EmailError
+from dmutils.timing import logged_duration_for_external_request as log_external_request, logged_duration
+
+from app.clam import get_clamd_socket, UnknownClamdError
+
+
+_filename_re = re.compile(r'^\s*filename=("?)(.+?)\1\s*$')
+
+
+def _filename_from_content_disposition(content_disposition):
+    return next(
+        (match.group(2) for match in (_filename_re.match(sect) for sect in content_disposition.split(";")) if match),
+        None,
+    )
+
+
+def _prefixed_tag_values_from_tag_set(tag_set, prefix):
+    return {tag["Key"]: tag["Value"] for tag in tag_set if tag["Key"].startswith(prefix)}
+
+
+def _tag_set_omitting_prefixed(tag_set, prefix):
+    return [tag for tag in tag_set if not tag["Key"].startswith(prefix)]
+
+
+# See https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/allocation-tag-restrictions.html
+_invalid_tag_chars_re = re.compile(r"[^-+=.:/\w\s]", flags=re.ASCII)
+
+
+def _tag_set_updated_with_dict(tag_set, update_dict):
+    return list(chain(
+        (kv for kv in tag_set if kv["Key"] not in update_dict),
+        ({"Key": k, "Value": _invalid_tag_chars_re.sub("_", v)} for k, v in update_dict.items()),
+    ))
+
+
+_nonhex_re = re.compile("[^0-9a-f]")
+
+
+def _normalize_hex(value):
+    return _nonhex_re.sub("", value.lower())
+
+
+def scan_s3_object(
+    aws_region,
+    s3_bucket_name,
+    s3_object_key,
+    s3_object_version,
+    sns_message_id=None,
+):
+    with logged_duration(
+        logger=current_app.logger,
+        message=lambda _: (
+            "Handled bucket {s3_bucket_name} key {s3_object_key} version {s3_object_version}"
+            if sys.exc_info()[0] is None else
+            # need to literally format() the exception into message as it's difficult to get it injected into extra
+            "Failed handling {{s3_bucket_name}} key {{s3_object_key}} version {{s3_object_version}}: {!r}".format(
+                sys.exc_info()[1]
+            )
+        ),
+        log_level=logging.INFO,
+        condition=True,
+    ) as log_context:
+        base_log_context = {
+            "s3_bucket_name": s3_bucket_name,
+            "s3_object_key": s3_object_key,
+            "s3_object_version": s3_object_version,
+        }
+        log_context.update(base_log_context)
+
+        # TODO abort if file too big?
+
+        s3_client = boto3.client("s3", region_name=aws_region)
+
+        with log_external_request(
+            "S3",
+            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            tagging_tag_set = s3_client.get_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )["TagSet"]
+
+        av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
+
+        if av_status.get("avStatus.result") is None:
+            current_app.logger.info(
+                "Object version {s3_object_version} has no 'avStatus.result' tag - will scan...",
+                extra={
+                    **base_log_context,
+                    "av_status": av_status,
+                },
+            )
+        else:
+            current_app.logger.info(
+                "Object version {s3_object_version} already has 'avStatus.result' "
+                "tag: {existing_av_status_result!r}",
+                extra={
+                    **base_log_context,
+                    "existing_av_status_result": av_status["avStatus.result"],
+                    "existing_av_status": av_status,
+                },
+            )
+            return
+
+        clamd_client = get_clamd_socket()
+        # first check our clamd is available - there's no point in going and fetching the object if we can't do
+        # anything with it. allow a raised exception to bubble up as a 500, which seems the most appropriate thing
+        # in this case
+        clamd_client.ping()
+
+        # the following two requests (to S3 for the file contents and to clamd for scanning) don't really happen
+        # sequentially as we're going to attempt to stream the data received from one into the other (by passing
+        # the StreamingBody file-like object from this response into .instream(...)), so these logged_duration
+        # sections do NOT *directly* correspond to the file being downloaded and then the file being scanned. The
+        # two activities will overlap in time, something that isn't expressible with logged_duration
+        with log_external_request(
+            "S3",
+            "initiate object download [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            s3_object = s3_client.get_object(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )
+
+        file_name = _filename_from_content_disposition(s3_object.get("ContentDisposition") or "")
+
+        with logged_duration(
+            logger=current_app.logger,
+            message=lambda _: (
+                "Scanned {file_length}byte file '{file_name}', result {clamd_result}"
+                if sys.exc_info()[0] is None else
+                # need to literally format() exception into message as it's difficult to get it injected into extra
+                "Failed scanning {{file_length}}byte file '{{file_name}}': {!r}".format(
+                    sys.exc_info()[1]
+                )
+            ),
+            log_level=logging.INFO,
+            condition=True,
+        ) as log_context_clamd:
+            log_context_clamd.update({
+                "file_length": s3_object["ContentLength"],
+                "file_name": file_name or "<unknown>",
+            })
+            clamd_result = clamd_client.instream(s3_object["Body"])["stream"]
+            log_context_clamd["clamd_result"] = clamd_result
+
+        if clamd_result[0] == "ERROR":
+            # let's hope this was a transient error and a later attempt may succeed. hard to know what else to do
+            # in this case - tagging a file with "ERROR" would prevent further attempts.
+            raise UnknownClamdError(f"clamd did not successfully scan file: {clamd_result!r}")
+
+        with logged_duration(
+            logger=current_app.logger,
+            message=lambda _: (
+                "Fetched clamd version string: {clamd_version}"
+                if sys.exc_info()[0] is None else
+                # need to literally format() exception into message as it's difficult to get it injected into extra
+                "Failed fetching clamd version string: {!r}".format(
+                    sys.exc_info()[1]
+                )
+            ),
+            log_level=logging.DEBUG,
+        ) as log_context_clamd:
+            # hypothetically there is a race condition between the time of scanning the file and fetching the
+            # version here when freshclam could give us a new definition file, making this information incorrect,
+            # but it's a very small possibility
+            clamd_version = clamd_client.version()
+            log_context_clamd.update({"clamd_version": clamd_version})
+
+        # we namespace all keys set as part of an avStatus update with an "avStatus." prefix, intending that all
+        # of these keys are only ever set or removed together as they are all information about the same scanning
+        # decision
+        new_av_status = {
+            "avStatus.result": "pass" if clamd_result[0] == "OK" else "fail",
+            "avStatus.clamdVerStr": clamd_version,
+            "avStatus.ts": datetime.datetime.utcnow().isoformat(),
+        }
+
+        # Now we briefly re-check the object's tags to ensure they weren't set by something else while we were
+        # scanning. Note the impossibility of avoiding all possible race conditions as S3's API doesn't allow any
+        # form of locking. What we *can* do is make the possible time period between check-tags and set-tags as
+        # small as possible...
+        with log_external_request(
+            "S3",
+            "get object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            tagging_tag_set = s3_client.get_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+            )["TagSet"]
+
+        av_status = _prefixed_tag_values_from_tag_set(tagging_tag_set, "avStatus.")
+
+        if av_status.get("avStatus.result") is not None:
+            current_app.logger.warning(
+                "Object was tagged with new 'avStatus.result' ({existing_av_status_result!r}) while we were "
+                "scanning. Not applying our own 'avStatus' ({unapplied_av_status_result!r})",
+                extra={
+                    "existing_av_status_result": av_status["avStatus.result"],
+                    "unapplied_av_status_result": new_av_status["avStatus.result"],
+                    "existing_av_status": av_status,
+                    "unapplied_av_status": new_av_status,
+                },
+            )
+            return
+
+        tagging_tag_set = _tag_set_updated_with_dict(
+            _tag_set_omitting_prefixed(tagging_tag_set, "avStatus."),
+            new_av_status,
+        )
+
+        with log_external_request(
+            "S3",
+            "put object tagging [{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}]",
+            logger=current_app.logger,
+        ) as log_context_s3:
+            log_context_s3.update(base_log_context)
+            s3_client.put_object_tagging(
+                Bucket=s3_bucket_name,
+                Key=s3_object_key,
+                VersionId=s3_object_version,
+                Tagging={"TagSet": tagging_tag_set},
+            )
+
+        if clamd_result[0] != "OK":
+            # TODO? attempt to rectify the situation:
+            # TODO? if this is (still) current version of object:
+            # TODO?     S3: find most recent version of object which is tagged "good"
+            # TODO?     if there is no such version:
+            # TODO?         S3: upload fail whale?
+            # TODO?     else copy that version to become new "current" ver for this key, ensuring to copy its tags
+            # TODO?         note the impossibility of doing this without some race conditions
+
+            notify_client = DMNotifyClient(current_app.config["DM_NOTIFY_API_KEY"])
+
+            if (
+                len(clamd_result) >= 2 and
+                clamd_result[1].lower() == current_app.config["DM_EICAR_TEST_SIGNATURE_RESULT_STRING"].lower()
+            ):
+                notify_kwargs = {
+                    # we'll use the s3 ETag of the file as the notify ref - it will be the only piece of information
+                    # that will be shared knowledge between a functional test and the application yet also allow the
+                    # test to differentiate the results of its different test runs, allowing it to easily check for
+                    # the message being sent
+                    "reference": "eicar-found-{}-{}".format(
+                        _normalize_hex(s3_object["ETag"]),
+                        current_app.config["DM_ENVIRONMENT"],
+                    ),
+                    "to_email_address": current_app.config["DM_EICAR_TEST_SIGNATURE_VIRUS_ALERT_EMAIL"],
+                }
+            else:
+                notify_kwargs = {
+                    "to_email_address": current_app.config["DM_DEVELOPER_VIRUS_ALERT_EMAIL"],
+                }
+
+            try:
+                notify_client.send_email(
+                    template_name_or_id="developer_virus_alert",
+                    personalisation={
+                        "region_name": aws_region,
+                        "bucket_name": s3_bucket_name,
+                        "object_key": s3_object_key,
+                        "object_version": s3_object_version,
+                        "file_name": file_name or "<unknown>",
+                        "clamd_output": ", ".join(clamd_result),
+                        "sns_message_id": sns_message_id,
+                        "dm_trace_id": getattr(request, "trace_id", None) or "<unknown>",
+                    },
+                    **notify_kwargs,
+                )
+            except EmailError as e:
+                current_app.logger.error(
+                    "Failed to send developer_virus_alert email after scanning "
+                    "{s3_bucket_name}/{s3_object_key} versionId {s3_object_version}: {e}",
+                    extra={
+                        **base_log_context,
+                        "e": str(e),
+                    },
+                )
+                # however we probably don't want this to cause a 500 because the main task has been completed - retrying
+                # it won't work and e.g. we eill want to signify to SNS that it should not attempt to re-send this
+                # message

--- a/config.py
+++ b/config.py
@@ -22,6 +22,9 @@ class Config:
 
     DM_NOTIFY_API_KEY = None
 
+    # only used as a surrogate where it doesn't actually matter (e.g. for s3)
+    DM_DEFAULT_AWS_REGION = "eu-west-1"
+
     DM_EICAR_TEST_SIGNATURE_RESULT_STRING = "Eicar-Test-Signature"
     DM_EICAR_TEST_SIGNATURE_VIRUS_ALERT_EMAIL = "eicar-found@example.gov.uk"
     DM_DEVELOPER_VIRUS_ALERT_EMAIL = "developer-virus-alert@example.com"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,15 @@
 import mock
 
+import boto3
 import clamd
 
+from moto.s3 import mock_s3
 import pytest
+
+from dmutils.timing import logged_duration
+
+
+_aws_region = "howth-west-2"
 
 
 @pytest.fixture()
@@ -17,7 +24,62 @@ def mock_clamd():
 
 @pytest.fixture
 def os_environ(request):
-    env_patch = mock.patch('os.environ', {})
-    request.addfinalizer(env_patch.stop)
+    with mock.patch('os.environ', {}) as mock_os_environ:
+        yield mock_os_environ
 
-    return env_patch.start()
+
+@pytest.fixture
+def s3_mock(request, os_environ):
+    # we don't want any real aws credentials this environment might have used in the tests
+    os_environ.update({
+        "AWS_ACCESS_KEY_ID": "AKIAIABCDABCDABCDABC",
+        "AWS_SECRET_ACCESS_KEY": "foobarfoobarfoobarfoobarfoobarfoobarfoob",
+    })
+
+    m = mock_s3()
+    m.start()
+    yield m
+    m.stop()
+
+
+@pytest.fixture
+def empty_bucket(request, s3_mock):
+    s3_res = boto3.resource("s3", region_name=_aws_region)
+    bucket = s3_res.Bucket("spade")
+    bucket.create()
+    bucket.Versioning().enable()
+    yield bucket
+
+
+@pytest.fixture
+def bucket_with_file(request, empty_bucket):
+    bucket = empty_bucket
+    obj = empty_bucket.Object("sandman/4321-billy-winks.pdf")
+    obj.put(
+        Body=b"123412341234",
+        Metadata={
+            "timestamp": "2005-04-03T02:01:00.12345Z",
+        },
+        ContentType="application/pdf",
+        ContentDisposition='attachment; filename="too ducky.puddeny-pie.pdf"',
+    )
+    yield bucket, obj.Version(obj.version_id)
+
+
+@pytest.fixture
+def force_all_logged_duration():
+    # this looks more complicated than it is - it simply forces the kwarg condition=True on all calls to logged_duration
+    def logged_duration_wrapper(*args, **kwargs):
+        return logged_duration(
+            *args,
+            **{**kwargs, "condition": True},
+        )
+
+    # apply this mock in multiple places
+    with mock.patch("app.callbacks.views.sns.logged_duration", autospec=True) as mock_sns_logged_duration:
+        mock_sns_logged_duration.side_effect = logged_duration_wrapper
+        with mock.patch("dmutils.timing.logged_duration", autospec=True) as mock_timing_logged_duration:
+            mock_timing_logged_duration.side_effect = logged_duration_wrapper
+            with mock.patch("app.s3.logged_duration", autospec=True) as mock_s3_logged_duration:
+                mock_s3_logged_duration.side_effect = logged_duration_wrapper
+                yield

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -21,3 +21,16 @@ class BaseApplicationTest:
         with mock.patch.object(self.app.logger, "isEnabledFor", return_value=True):
             with mock.patch.object(self.app.logger, "_log") as _log:
                 yield _log
+
+
+@contextlib.contextmanager
+def null_context_manager():
+    yield
+
+
+def dict_from_tagset(tagset_seq):
+    return {k_v["Key"]: k_v["Value"] for k_v in tagset_seq}
+
+
+def tagset_from_dict(input_dict):
+    return [{"Key": k, "Value": v} for k, v in input_dict.items()]

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -113,7 +113,7 @@ class TestScanS3Object(BaseApplicationTest):
     def test_correct_passthrough(self, mock_scan_and_tag_s3_object, bucket_with_file):
         bucket, objver = bucket_with_file
         client = self.get_authorized_client()
-        mock_scan_and_tag_s3_object.return_value = {}, True, {}
+        mock_scan_and_tag_s3_object.return_value = {"delectable": "swig"}, True, {"gurgling": "noise"}
         res = client.post(
             "/scan/s3-object",
             data=json.dumps({
@@ -127,9 +127,9 @@ class TestScanS3Object(BaseApplicationTest):
         assert res.status_code == 200
         assert res.content_type == "application/json"
         assert json.loads(res.get_data()) == {
-            "existingAvStatus": {},
+            "existingAvStatus": {"delectable": "swig"},
             "avStatusApplied": True,
-            "newAvStatus": {},
+            "newAvStatus": {"gurgling": "noise"},
         }
 
         assert mock_scan_and_tag_s3_object.call_args_list == [

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -1,0 +1,142 @@
+import json
+import mock
+
+from ..helpers import BaseApplicationTest
+
+
+class TestScanS3Object(BaseApplicationTest):
+    @mock.patch("app.main.views.scan.scan_and_tag_s3_object", autospec=True)
+    def test_missing_json_keys(self, mock_scan_and_tag_s3_object):
+        client = self.get_authorized_client()
+        res = client.post(
+            "/scan/s3-object",
+            data=json.dumps({
+                "bucketName": "defense-duriner",
+                "objectVersionId": "abcdef54321wxyz",
+            }),
+            content_type="application/json",
+        )
+
+        assert res.status_code == 400
+        assert res.content_type == "application/json"
+        assert json.loads(res.get_data()) == {
+            "error": "Expected top-level JSON keys: ['objectKey']",
+        }
+
+        assert mock_scan_and_tag_s3_object.called is False
+
+    @mock.patch("app.main.views.scan.scan_and_tag_s3_object", autospec=True)
+    def test_json_not_obj(self, mock_scan_and_tag_s3_object):
+        client = self.get_authorized_client()
+        res = client.post(
+            "/scan/s3-object",
+            data=json.dumps(54321),
+            content_type="application/json",
+        )
+
+        assert res.status_code == 400
+        assert res.content_type == "application/json"
+        assert json.loads(res.get_data()) == {
+            "error": "Expected content to be JSON object",
+        }
+
+        assert mock_scan_and_tag_s3_object.called is False
+
+    @mock.patch("app.main.views.scan.scan_and_tag_s3_object", autospec=True)
+    def test_nonexistent_bucket(self, mock_scan_and_tag_s3_object, s3_mock):
+        client = self.get_authorized_client()
+        res = client.post(
+            "/scan/s3-object",
+            data=json.dumps({
+                "bucketName": "defense-duriner",
+                "objectKey": "sublime-mason.odt",
+                "objectVersionId": "abcdef54321wxyz",
+            }),
+            content_type="application/json",
+        )
+
+        assert res.status_code == 400
+        assert res.content_type == "application/json"
+        assert json.loads(res.get_data()) == {
+            "error": "Bucket 'defense-duriner' not found",
+        }
+
+        assert mock_scan_and_tag_s3_object.called is False
+
+    @mock.patch("app.main.views.scan.scan_and_tag_s3_object", autospec=True)
+    def test_nonexistent_object(self, mock_scan_and_tag_s3_object, empty_bucket):
+        client = self.get_authorized_client()
+        res = client.post(
+            "/scan/s3-object",
+            data=json.dumps({
+                "bucketName": empty_bucket.name,
+                "objectKey": "sublime-mason.odt",
+                "objectVersionId": "abcdef54321wxyz",
+            }),
+            content_type="application/json",
+        )
+
+        assert res.status_code == 400
+        assert res.content_type == "application/json"
+        assert json.loads(res.get_data()) == {
+            "error": "Object with key 'sublime-mason.odt' and version 'abcdef54321wxyz' not found in bucket 'spade'",
+        }
+
+        assert mock_scan_and_tag_s3_object.called is False
+
+    @mock.patch("app.main.views.scan.scan_and_tag_s3_object", autospec=True)
+    def test_nonexistent_version(self, mock_scan_and_tag_s3_object, bucket_with_file):
+        bucket, objver = bucket_with_file
+        client = self.get_authorized_client()
+        res = client.post(
+            "/scan/s3-object",
+            data=json.dumps({
+                "bucketName": bucket.name,
+                "objectKey": objver.Object().key,
+                "objectVersionId": "abcdef54321wxyz",
+            }),
+            content_type="application/json",
+        )
+
+        assert res.status_code == 400
+        assert res.content_type == "application/json"
+        assert json.loads(res.get_data()) == {
+            "error": (
+                "Object with key 'sandman/4321-billy-winks.pdf' and version 'abcdef54321wxyz' not found in "
+                "bucket 'spade'"
+            ),
+        }
+
+        assert mock_scan_and_tag_s3_object.called is False
+
+    @mock.patch("app.main.views.scan.scan_and_tag_s3_object", autospec=True)
+    def test_correct_passthrough(self, mock_scan_and_tag_s3_object, bucket_with_file):
+        bucket, objver = bucket_with_file
+        client = self.get_authorized_client()
+        mock_scan_and_tag_s3_object.return_value = {}, True, {}
+        res = client.post(
+            "/scan/s3-object",
+            data=json.dumps({
+                "bucketName": bucket.name,
+                "objectKey": objver.Object().key,
+                "objectVersionId": objver.id,
+            }),
+            content_type="application/json",
+        )
+
+        assert res.status_code == 200
+        assert res.content_type == "application/json"
+        assert json.loads(res.get_data()) == {
+            "existingAvStatus": {},
+            "avStatusApplied": True,
+            "newAvStatus": {},
+        }
+
+        assert mock_scan_and_tag_s3_object.call_args_list == [
+            mock.call(
+                s3_client=mock.ANY,
+                s3_bucket_name=bucket.name,
+                s3_object_key=objver.Object().key,
+                s3_object_version=objver.id,
+            )
+        ]

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,0 +1,13 @@
+import pytest
+
+from app.s3 import _filename_from_content_disposition
+
+
+@pytest.mark.parametrize("cd_string,expected_output", (
+    ("a", None,),
+    ("attachment; filename=abcd3_ .pdf ", "abcd3_ .pdf",),
+    ('bla; bla; filename="things...other...things.PNG";', "things...other...things.PNG",),
+    (';filename= 8765432', " 8765432",),
+))
+def test_filename_from_content_disposition(cd_string, expected_output):
+    assert _filename_from_content_disposition(cd_string) == expected_output

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1,6 +1,24 @@
+import logging
+
+import boto3
+from freezegun import freeze_time
+import mock
 import pytest
 
-from app.s3 import _filename_from_content_disposition
+from dmtestutils.comparisons import AnySupersetOf, AnyStringMatching, RestrictedAny
+
+from app.clam import UnknownClamdError
+from app.s3 import _filename_from_content_disposition, scan_and_tag_s3_object
+
+from .helpers import (
+    BaseApplicationTest,
+    tagset_from_dict,
+    dict_from_tagset,
+    null_context_manager,
+)
+
+
+pytestmark = pytest.mark.usefixtures("force_all_logged_duration")
 
 
 @pytest.mark.parametrize("cd_string,expected_output", (
@@ -11,3 +29,827 @@ from app.s3 import _filename_from_content_disposition
 ))
 def test_filename_from_content_disposition(cd_string, expected_output):
     assert _filename_from_content_disposition(cd_string) == expected_output
+
+
+class TestScanAndTagS3Object(BaseApplicationTest):
+    @pytest.mark.parametrize(
+        (
+            "initial_tagset",
+            "concurrent_new_tagset",
+            "clamd_instream_retval",
+            "expected_retval",
+            "expected_log_calls",
+            "expected_notify_calls",
+            "expected_tagset",
+        ),
+        (
+            (
+                # initial_tagset
+                {
+                    "existing": "tag123",
+                    "avStatus.irrelevant": "who is here",
+                },
+                # concurrent_new_tagset
+                {"surprise": "tag234"},
+                # clamd_instream_retval
+                {"stream": ("OK", "dénouement sufficient",)},
+                # expected_retval
+                (
+                    {},
+                    True,
+                    {
+                        "avStatus.clamdVerStr": "ClamAV 567; first watch",
+                        "avStatus.result": "pass",
+                        "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    },
+                ),
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus\.result. tag "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "av_status": {"avStatus.irrelevant": "who is here"},
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Scanned "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "file_length": 12,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "clamd_result": ("OK", "dénouement sufficient"),
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Fetched clamd version "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "clamd_version": "ClamAV 567; first watch",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(put object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (),
+                # expected_tagset
+                {
+                    "avStatus.result": "pass",
+                    "avStatus.clamdVerStr": "ClamAV 567_ first watch",
+                    "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    "surprise": "tag234",
+                },
+            ),
+            (
+                # initial_tagset
+                {"existing": "tag123"},
+                # concurrent_new_tagset
+                {"surprise": "tag234"},
+                # clamd_instream_retval
+                {"stream": ("FOUND", "After him, Garry!",)},
+                # expected_retval
+                (
+                    {},
+                    True,
+                    {
+                        "avStatus.clamdVerStr": "ClamAV 567; first watch",
+                        "avStatus.result": "fail",
+                        "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    },
+                ),
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus\.result. tag "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "av_status": {},
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Scanned "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "file_length": 12,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "clamd_result": ("FOUND", "After him, Garry!"),
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Fetched clamd version "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "clamd_version": "ClamAV 567; first watch",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(put object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (
+                    mock.call("not_a_real_key-00000000-fake-uuid-0000-000000000000"),
+                    mock.call().send_email(
+                        to_email_address="developer-virus-alert@example.com",
+                        personalisation={
+                            "bucket_name": "spade",
+                            "clamd_output": "FOUND, After him, Garry!",
+                            "dm_trace_id": mock.ANY,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "object_key": "sandman/4321-billy-winks.pdf",
+                            "object_version": "0",
+                            "sns_message_id": "<N/A>",
+                        },
+                        template_name_or_id="developer_virus_alert",
+                    ),
+                ),
+                # expected_tagset
+                {
+                    "avStatus.result": "fail",
+                    "avStatus.clamdVerStr": "ClamAV 567_ first watch",
+                    "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    "surprise": "tag234",
+                }
+            ),
+            (
+                # initial_tagset
+                {"existing": "tag123"},
+                # concurrent_new_tagset
+                None,
+                # clamd_instream_retval
+                {"stream": ("FOUND", "eicar-test-signature",)},
+                # expected_retval
+                (
+                    {},
+                    True,
+                    {
+                        "avStatus.clamdVerStr": "ClamAV 567; first watch",
+                        "avStatus.result": "fail",
+                        "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    },
+                ),
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus\.result. tag "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "av_status": {},
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Scanned "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "file_length": 12,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "clamd_result": ("FOUND", "eicar-test-signature"),
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Fetched clamd version "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "clamd_version": "ClamAV 567; first watch",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(put object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (
+                    mock.call("not_a_real_key-00000000-fake-uuid-0000-000000000000"),
+                    mock.call().send_email(
+                        to_email_address="eicar-found@example.gov.uk",
+                        personalisation={
+                            "bucket_name": "spade",
+                            "clamd_output": "FOUND, eicar-test-signature",
+                            "dm_trace_id": mock.ANY,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "object_key": "sandman/4321-billy-winks.pdf",
+                            "object_version": "0",
+                            "sns_message_id": "<N/A>",
+                        },
+                        template_name_or_id="developer_virus_alert",
+                        reference="eicar-found-4d3daeeb3ea3d90d4d6e7a20a5b483a9-development",
+                    ),
+                ),
+                # expected_tagset
+                {
+                    "avStatus.result": "fail",
+                    "avStatus.clamdVerStr": "ClamAV 567_ first watch",
+                    "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    "existing": "tag123",
+                }
+            ),
+            (
+                # initial_tagset
+                {"existing": "tag123"},
+                # concurrent_new_tagset
+                {
+                    "surprise": "tag234",
+                    "avStatus.ts": "2010-09-08T07:06:05.040302",
+                },
+                # clamd_instream_retval
+                {"stream": ("ERROR", " Some trouble is on here",)},
+                # expected_retval
+                UnknownClamdError,
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus\.result. tag "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "av_status": {},
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Scanned "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "file_length": 12,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "clamd_result": ("ERROR", " Some trouble is on here",),
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Failed handling.*UnknownClamdError.*"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (),
+                # expected_tagset
+                {
+                    "surprise": "tag234",
+                    "avStatus.ts": "2010-09-08T07:06:05.040302",
+                },
+            ),
+            (
+                # initial_tagset
+                {"existing": "tag123"},
+                # concurrent_new_tagset
+                {
+                    "avStatus.result": "fail",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                    "avStatus.irrelevant": "who is here",
+                },
+                # clamd_instream_retval
+                {"stream": ("OK", "Egg two demolished",)},
+                # expected_retval
+                (
+                    {
+                        "avStatus.result": "fail",
+                        "avStatus.ts": "2010-09-08T07:06:04.010101",
+                        "avStatus.irrelevant": "who is here",
+                    },
+                    False,
+                    {
+                        "avStatus.clamdVerStr": "ClamAV 567; first watch",
+                        "avStatus.result": "pass",
+                        "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    },
+                ),
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus\.result. tag "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "av_status": {},
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Scanned "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "file_length": 12,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "clamd_result": ("OK", "Egg two demolished"),
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Fetched clamd version "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "clamd_version": "ClamAV 567; first watch",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (
+                            logging.WARNING,
+                            AnyStringMatching(r"Object was tagged.*existing.*unapplied.*"),
+                            (),
+                        ),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "existing_av_status": {
+                                "avStatus.result": "fail",
+                                "avStatus.ts": "2010-09-08T07:06:04.010101",
+                                "avStatus.irrelevant": "who is here",
+                            },
+                            "existing_av_status_result": "fail",
+                            "unapplied_av_status": {
+                                "avStatus.result": "pass",
+                                "avStatus.clamdVerStr": "ClamAV 567; first watch",
+                                "avStatus.ts": "2010-09-08T07:06:05.040302",
+                            },
+                            "unapplied_av_status_result": "pass",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (),
+                # expected_tagset
+                {
+                    "avStatus.result": "fail",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                    "avStatus.irrelevant": "who is here",
+                },
+            ),
+            (
+                # initial_tagset
+                {"existing": "tag123"},
+                # concurrent_new_tagset
+                {
+                    "avStatus.result": "pass",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                    "avStatus.clamdVerStr": "4321_ 7654",
+                    "surprise": "789+789",
+                },
+                # clamd_instream_retval
+                {"stream": ("FOUND", "After him, boy!",)},
+                # expected_retval
+                (
+                    {
+                        "avStatus.result": "pass",
+                        "avStatus.ts": "2010-09-08T07:06:04.010101",
+                        "avStatus.clamdVerStr": "4321_ 7654",
+                    },
+                    False,
+                    {
+                        "avStatus.clamdVerStr": "ClamAV 567; first watch",
+                        "avStatus.result": "fail",
+                        "avStatus.ts": "2010-09-08T07:06:05.040302",
+                    },
+                ),
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version .* has no .avStatus\.result. tag "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "av_status": {},
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Scanned "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "file_length": 12,
+                            "file_name": "too ducky.puddeny-pie.pdf",
+                            "clamd_result": ("FOUND", "After him, boy!"),
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Fetched clamd version "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "clamd_version": "ClamAV 567; first watch",
+                        })}),
+                    ),
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (
+                            logging.WARNING,
+                            AnyStringMatching(r"Object was tagged.*existing.*unapplied.*"),
+                            (),
+                        ),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "existing_av_status": {
+                                "avStatus.result": "pass",
+                                "avStatus.ts": "2010-09-08T07:06:04.010101",
+                                "avStatus.clamdVerStr": "4321_ 7654",
+                            },
+                            "existing_av_status_result": "pass",
+                            "unapplied_av_status": {
+                                "avStatus.result": "fail",
+                                "avStatus.clamdVerStr": "ClamAV 567; first watch",
+                                "avStatus.ts": "2010-09-08T07:06:05.040302",
+                            },
+                            "unapplied_av_status_result": "fail",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (),
+                # expected_tagset
+                {
+                    "avStatus.result": "pass",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                    "avStatus.clamdVerStr": "4321_ 7654",
+                    "surprise": "789+789",
+                },
+            ),
+            (
+                # initial_tagset
+                {
+                    "avStatus.result": "pass",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                },
+                # concurrent_new_tagset
+                None,
+                # clamd_instream_retval
+                None,
+                # expected_retval
+                (
+                    {
+                        "avStatus.result": "pass",
+                        "avStatus.ts": "2010-09-08T07:06:04.010101",
+                    },
+                    False,
+                    None,
+                ),
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version.*already.*avStatus\.result.*tag.+"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "existing_av_status": {
+                                "avStatus.result": "pass",
+                                "avStatus.ts": "2010-09-08T07:06:04.010101",
+                            },
+                            "existing_av_status_result": "pass",
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (),
+                # expected_tagset
+                {
+                    "avStatus.result": "pass",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                },
+            ),
+            (
+                # initial_tagset
+                {
+                    "avStatus.result": "fail",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                },
+                # concurrent_new_tagset
+                None,
+                # clamd_instream_retval
+                None,
+                # expected_retval
+                (
+                    {
+                        "avStatus.result": "fail",
+                        "avStatus.ts": "2010-09-08T07:06:04.010101",
+                    },
+                    False,
+                    None,
+                ),
+                # expected_log_calls
+                (
+                    (
+                        (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Object version.*already.*avStatus\.result.*tag.+"), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "existing_av_status": {
+                                "avStatus.result": "fail",
+                                "avStatus.ts": "2010-09-08T07:06:04.010101",
+                            },
+                            "existing_av_status_result": "fail",
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                    (
+                        (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
+                        AnySupersetOf({"extra": AnySupersetOf({
+                            "s3_bucket_name": "spade",
+                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_version": "0",
+                        })}),
+                    ),
+                ),
+                # expected_notify_calls
+                (),
+                # expected_tagset
+                {
+                    "avStatus.result": "fail",
+                    "avStatus.ts": "2010-09-08T07:06:04.010101",
+                },
+            ),
+        ),
+    )
+    @freeze_time("2010-09-08T07:06:05.040302")
+    @mock.patch("app.s3.DMNotifyClient", autospec=True)
+    def test_scan_and_tag_s3_object(
+        self,
+        mock_notify_client,
+        bucket_with_file,
+        mock_clamd,
+        initial_tagset,
+        concurrent_new_tagset,
+        clamd_instream_retval,
+        expected_retval,
+        expected_log_calls,
+        expected_notify_calls,
+        expected_tagset,
+    ):
+        """
+        :param initial_tagset:        tagset (dict) that file in bucket will appear to have initially
+        :param concurrent_new_tagset: a tagset (dict) that coincidentally gets set "while" the clam instream process
+                                      is running, None to skip this update
+        :param clamd_instream_retval: value to return from mock clamd instream(...) call, None to expect no call to
+                                      take place
+        :param expected_retval:       return value to expect from call, or, if a subclass of Exception, expect to raise
+                                      this exception type
+        :param expected_log_calls:    sequence of expected mock.call()s to have been made to app logger
+        :param expected_notify_calls: sequence of expected mock.call()s to have been made to mock DMNotifyClient
+        :param expected_tagset:       tagset (dict) to expect file to have after the request processing has finished
+        """
+        bucket, objver = bucket_with_file
+        s3_client = boto3.client("s3", region_name="howth-west-2")
+
+        if initial_tagset is not None:
+            s3_client.put_object_tagging(
+                Bucket=bucket.name,
+                Key=objver.Object().key,
+                VersionId=objver.id,
+                Tagging={"TagSet": tagset_from_dict(initial_tagset)},
+            )
+
+        def clamd_instream_func(*args, **kwargs):
+            # if clamd_instream_retval *is* None, we'd be expecting "instream" not to be called at all
+            assert clamd_instream_retval is not None
+
+            assert args == (RestrictedAny(lambda x: x.read() == b"123412341234"),)
+            assert kwargs == {}
+
+            if concurrent_new_tagset is not None:
+                # a very literal "side effect" here - simulating a modification to the object's tags while scanning...
+                s3_client.put_object_tagging(
+                    Bucket=bucket.name,
+                    Key=objver.Object().key,
+                    VersionId=objver.id,
+                    Tagging={"TagSet": tagset_from_dict(concurrent_new_tagset)},
+                )
+
+            return clamd_instream_retval
+
+        mock_clamd.instream.side_effect = clamd_instream_func
+        mock_clamd.version.return_value = "ClamAV 567; first watch"
+
+        with self.mocked_app_logger_log() as mock_app_log:
+            with pytest.raises(expected_retval) if (
+                isinstance(expected_retval, type)
+                and issubclass(expected_retval, Exception)
+            ) else null_context_manager():
+                with self.app.test_request_context():
+                    retval = scan_and_tag_s3_object(
+                        s3_client,
+                        bucket.name,
+                        objver.Object().key,
+                        objver.id,
+                    )
+
+            if not (isinstance(expected_retval, type) and issubclass(expected_retval, Exception)):
+                assert retval == expected_retval
+
+            assert mock_app_log.call_args_list == list(expected_log_calls)
+            assert mock_notify_client.mock_calls == list(expected_notify_calls)
+
+            assert dict_from_tagset(
+                s3_client.get_object_tagging(
+                    Bucket=bucket.name,
+                    Key=objver.Object().key,
+                    VersionId=objver.id,
+                )["TagSet"]
+            ) == expected_tagset


### PR DESCRIPTION
https://trello.com/c/t0TuxSsb/387-non-sns-endpoint-to-process-a-file-for-virus-scanning

This is quite a basic endpoint intended mostly to be the target of a script yet to be written that will allow a bucket to be scanned "in bulk", either as a catch-up script or to add tags to a previously un-scanned bucket.

The endpoint is a POST request, accepting json containing the `bucketName`, `objectKey` and `objectVersionId` parameters. 

To support this, this PR includes quite a bit of refactoring, moving the "business" function to `app.s3` as `scan_and_tag_s3_object`. The return values (of both the function and view) should be enough to give a full picture of the findings of the scan and action the procedure took.

Another thing still to do is add this endpoint (and a whole new av-api client) to `digitalmarketplace-apiclient`.