### PR TITLE
Add a Python version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://travis-ci.org/alphagov/digitalmarketplace-antivirus-api.svg?branch=master)](https://travis-ci.org/alphagov/digitalmarketplace-antivirus-api)
 [![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-antivirus-api/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-antivirus-api?branch=master)
 [![Requirements Status](https://requires.io/github/alphagov/digitalmarketplace-antivirus-api/requirements.svg?branch=master)](https://requires.io/github/alphagov/digitalmarketplace-antivirus-api/requirements/?branch=master)
+![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 App to scan files in S3 buckets for viruses on demand.
 


### PR DESCRIPTION
Adds a nifty visual indicator of what versions of Python we support

Part of https://trello.com/c/wWFsv1SU/230-be-clear-in-our-libraries-what-versions-of-python-we-support