### PR TITLE
status checks: split "stats" out into separate, external, "clamd.extended" check

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -6,6 +6,22 @@ from ..clam import get_clamd_socket
 from dmutils.status import get_app_status, StatusError
 
 
+def get_clamd_stats():
+    client = get_clamd_socket()
+
+    try:
+        return {
+            'clamd.extended': {
+                'stats': client.stats(),
+            },
+        }
+
+    except clamd.ClamdError as e:
+        raise StatusError(str(e))
+
+    raise StatusError('Unknown error')
+
+
 def get_clamd_status():
     client = get_clamd_socket()
 
@@ -14,7 +30,6 @@ def get_clamd_status():
             return {
                 'clamd': {
                     'status': 'OK',
-                    'stats': client.stats()
                 },
             }
 
@@ -28,5 +43,6 @@ def get_clamd_status():
 def status():
     return get_app_status(
         ignore_dependencies='ignore-dependencies' in request.args,
+        additional_checks=[get_clamd_stats],
         additional_checks_internal=[get_clamd_status],
     )


### PR DESCRIPTION
...so that a pause, possibly caused by the "stats" call, doesn't cause a healthcheck to fail.

https://trello.com/c/a1HWW3Bd/550-antivirus-api-crashes

The output of this is now a _little_ ugly, having `"clamd"` and `"clamd.extended"` sections, but short of modifying the utils to be able to do deep merges, and seeing as this might not have any effect anyway, this is probably the most effective thing to do for now.

I note, looking at the "stats", that scraping these through prometheus might be an interesting experiment.