### PR TITLE
status check: move all clamd checking to being an "external" dependency

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -6,30 +6,15 @@ from ..clam import get_clamd_socket
 from dmutils.status import get_app_status, StatusError
 
 
-def get_clamd_stats():
-    client = get_clamd_socket()
-
-    try:
-        return {
-            'clamd.extended': {
-                'stats': client.stats(),
-            },
-        }
-
-    except clamd.ClamdError as e:
-        raise StatusError(str(e))
-
-    raise StatusError('Unknown error')
-
-
-def get_clamd_status():
+def get_clamd_status_extended():
     client = get_clamd_socket()
 
     try:
         if client.ping() == 'PONG':
             return {
-                'clamd': {
-                    'status': 'OK',
+                'clamd.extended': {
+                    'ping': 'OK',
+                    'stats': client.stats(),
                 },
             }
 
@@ -43,6 +28,5 @@ def get_clamd_status():
 def status():
     return get_app_status(
         ignore_dependencies='ignore-dependencies' in request.args,
-        additional_checks=[get_clamd_stats],
-        additional_checks_internal=[get_clamd_status],
+        additional_checks=[get_clamd_status_extended],
     )


### PR DESCRIPTION
https://trello.com/c/a1HWW3Bd/550-antivirus-api-crashes

This is hopefully temporary so we can verify that these are what is causing the app "crashes".