### PR TITLE
status checks: add new additional_checks_internal which simply sends an empty signal to check process responsiveness…

### DIFF
--- a/app/status/views.py
+++ b/app/status/views.py
@@ -1,12 +1,47 @@
 import clamd
-from flask import request
+from flask import current_app, request
+from psutil import net_connections, Process
 
 from . import status
 from ..clam import get_clamd_socket
 from dmutils.status import get_app_status, StatusError
 
 
+def get_clamd_status():
+    """
+        This "additional checks" function performs a very relaxed (but fast!) test to get an idea whether the clamd
+        server is running or not FSVO "running". By that we mean that there is a process listening on
+        DM_CLAMD_UNIX_SOCKET_PATH and that process is able to respond to signals (not stuck in an "uninterruptible"
+        state). PaaS healthcheck requests have tight time constraints and it would seem that any more thorough clamd
+        status checks can't reliably return within a second.
+    """
+    try:
+        pid = next(
+            conn.pid
+            for conn in net_connections(kind="unix")
+            if conn.laddr == current_app.config["DM_CLAMD_UNIX_SOCKET_PATH"]
+        )
+    except StopIteration:
+        raise StatusError('No connection found matching DM_CLAMD_UNIX_SOCKET_PATH')
+
+    if not pid:
+        # insufficient permissions?
+        raise StatusError("Unable to determine pid of process connected to DM_CLAMD_UNIX_SOCKET_PATH")
+
+    process = Process(pid)
+    process.send_signal(0)
+
+    return {
+        'clamd': {
+            'process': 'alive',
+        },
+    }
+
+
 def get_clamd_status_extended():
+    """
+        More thorough tests of clamd's operational state for when the request doesn't have such tight time constraints
+    """
     client = get_clamd_socket()
 
     try:
@@ -29,4 +64,5 @@ def status():
     return get_app_status(
         ignore_dependencies='ignore-dependencies' in request.args,
         additional_checks=[get_clamd_status_extended],
+        additional_checks_internal=[get_clamd_status],
     )

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -6,6 +6,7 @@ Flask==1.0.2
 itsdangerous==0.24
 lxml==4.2.5
 validatesns==0.1.1
+psutil==5.4.8
 # Pinned because requests requires <2.8 but earlier dependencies in the list will install 2.8
 idna==2.7
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask==1.0.2
 itsdangerous==0.24
 lxml==4.2.5
 validatesns==0.1.1
+psutil==5.4.8
 # Pinned because requests requires <2.8 but earlier dependencies in the list will install 2.8
 idna==2.7
 


### PR DESCRIPTION
https://trello.com/c/a1HWW3Bd/550-antivirus-api-crashes

This is crude, but better than nothing. should be able to detect processes that have e.g. deadlocked to the point of not being able to handle a signal. New dependency on psutil to allow us to discover the pid of the process listening on `DM_CLAMD_UNIX_SOCKET_PATH`.

A bit of a pain to informally, as for unit tests, don't even go there. (actually I have a couple of ideas of how they could be done). To test locally, you can actually use any old simple tool that will listen on a unix socket and briefly set `DM_CLAMD_UNIX_SOCKET_PATH` to that socket path and check it picks up on that process being alive or dead. I used `$ socat - UNIX-LISTEN:/tmp/bla`.