### PR TITLE
Bump docker base image to 4.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:3.1.1
+FROM digitalmarketplace/base-api:4.0.0
 
 ENV CLAMAV_VERSION 0.
 


### PR DESCRIPTION
This had got left a bit behind.