### PR TITLE
Bump docker base image to 4.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:4.1.0
+FROM digitalmarketplace/base-api:4.3.0
 
 ENV CLAMAV_VERSION 0.
 


### PR DESCRIPTION
To enable https://trello.com/c/H53K45It