### PR TITLE
Adds PyUp config (weekly on Sundays)

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,21 @@
+# PyUp config
+# https://pyup.io/docs/bot/config/
+# Check dependencies in _only_ requirements-app and requirements-dev, and open PRs with PyUp prefix.
+
+search: False
+schedule: "every week on sunday"
+
+requirements:
+
+  - requirements-app.txt:
+      update: all
+      pin: True
+
+  - requirements-dev.txt:
+      update: all
+      pin: True
+
+  - requirements.txt:
+      update: False
+
+pr_prefix: "PyUp - "


### PR DESCRIPTION
https://trello.com/c/mBmxDwfC/823-make-pyup-prs-appear-in-the-morning

Turns out we didn't have PyUp on Antivirus API yet. I've copied the config from the API app.