### PR TITLE
handle shutdown better

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:4.4.2
+FROM digitalmarketplace/base-api:4.5.4
 
 ENV CLAMAV_VERSION 0.
 

--- a/config/additional-supervisord.conf
+++ b/config/additional-supervisord.conf
@@ -18,4 +18,10 @@ stdout_logfile_maxbytes = 0
 stderr_logfile = /var/log/clamd.log
 stderr_logfile_maxbytes = 5000000
 stderr_logfile_backups = 3
-stopsignal = INT
+# SIGHUP actually just makes clamd reopen its logfiles, but really we want to keep clamd up almost as long as
+# it'll be allowed so that the uwsgi app can use it in trying to clear its request backlog before
+# its grace period runs out
+stopsignal = HUP
+# bosh will probably kill everything after 10s - stop a second early in the hopes that the logs of our
+# last handled request make it off the machine
+stopwaitsecs = 9

--- a/default.nix
+++ b/default.nix
@@ -7,12 +7,24 @@ let
     forDev = true;
     localOverridesPath = ./local.nix;
   } // argsOuter;
+  sitePrioNonNix = args.pkgs.writeTextFile {
+    name = "site-prio-non-nix";
+    destination = "/${args.pythonPackages.python.sitePackages}/sitecustomize.py";
+    text = ''
+      import sys
+      first_nix_i = next((i for i, p in enumerate(sys.path) if p.startswith("/nix/")), 1)
+      # after the first nix-provided path in sys.path (presumably the python stdlib itself), re-sort all non-nix
+      # paths to be before the nix paths. this is helped by python's sort being a stable-sort
+      sys.path[first_nix_i+1:] = sorted(sys.path[first_nix_i+1:], key=lambda p: p.startswith("/nix/"))
+    '';
+  };
 in (with args; {
   digitalMarketplaceApiEnv = (pkgs.stdenv.mkDerivation rec {
     name = "digitalmarketplace-antivirus-api-env";
     shortName = "dm-av-api";
     buildInputs = [
       pythonPackages.python
+      sitePrioNonNix
       pkgs.glibcLocales
       pkgs.clamav
       pkgs.libffi


### PR DESCRIPTION
https://trello.com/c/0CgzmFeD

This PR includes both the base image bump which should improve the common daemons' shutdown but also the `clamd`-specific settings.

Also squeezed in a `default.nix` fix.