### PR TITLE
handle_s3_sns: url-unquote s3 key sent to us in SNS events

### DIFF
--- a/app/callbacks/views/sns.py
+++ b/app/callbacks/views/sns.py
@@ -3,6 +3,7 @@ from functools import lru_cache
 import json
 import logging
 import sys
+from urllib.parse import unquote_plus
 
 import boto3
 from flask import abort, jsonify, current_app, request
@@ -192,7 +193,7 @@ def handle_s3_sns(body_dict):
             scan_and_tag_s3_object(
                 s3_client=boto3.client("s3", region_name=record["awsRegion"]),
                 s3_bucket_name=record["s3"]["bucket"]["name"],
-                s3_object_key=record["s3"]["object"]["key"],
+                s3_object_key=unquote_plus(record["s3"]["object"]["key"]),
                 s3_object_version=record["s3"]["object"]["versionId"],
                 sns_message_id=body_dict["MessageId"],
             )

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -1,6 +1,7 @@
 from itertools import chain
 import json
 import logging
+from urllib.parse import quote_plus
 
 from freezegun import freeze_time
 from flask.wrappers import Response
@@ -652,7 +653,7 @@ class TestHandleS3Sns(BaseCallbackApplicationTest):
                                     "name": bucket.name,
                                 },
                                 "object": {
-                                    "key": objver.Object().key,
+                                    "key": quote_plus(objver.Object().key),
                                     "versionId": objver.id,
                                 },
                             },

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,7 +54,7 @@ def empty_bucket(request, s3_mock):
 @pytest.fixture
 def bucket_with_file(request, empty_bucket):
     bucket = empty_bucket
-    obj = empty_bucket.Object("sandman/4321-billy-winks.pdf")
+    obj = empty_bucket.Object("sandman/+4321 billy-winks☾.pdf")
     obj.put(
         Body=b"123412341234",
         Metadata={

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -113,7 +113,7 @@ class TestScanS3Object(BaseApplicationTest):
         assert res.content_type == "application/json"
         assert json.loads(res.get_data()) == {
             "error": (
-                "Object with key 'sandman/4321-billy-winks.pdf' and version 'abcdef54321wxyz' not found in "
+                "Object with key 'sandman/+4321 billy-winks☾.pdf' and version 'abcdef54321wxyz' not found in "
                 "bucket 'spade'"
             ),
         }
@@ -152,7 +152,7 @@ class TestScanS3Object(BaseApplicationTest):
         assert res.status_code == 400
         assert res.content_type == "application/json"
         assert json.loads(res.get_data()) == {
-            "error": "Access to key 'sandman/4321-billy-winks.pdf' version '0' in bucket 'spade' forbidden",
+            "error": "Access to key 'sandman/+4321 billy-winks☾.pdf' version '0' in bucket 'spade' forbidden",
         }
 
         assert mock_scan_and_tag_s3_object.called is False

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -69,7 +69,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -78,7 +78,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         AnySupersetOf({"extra": AnySupersetOf({
                             "av_status": {"avStatus.irrelevant": "who is here"},
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -86,7 +86,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -108,7 +108,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -116,7 +116,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(put object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -124,7 +124,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -162,7 +162,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -171,7 +171,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         AnySupersetOf({"extra": AnySupersetOf({
                             "av_status": {},
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -179,7 +179,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -201,7 +201,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -209,7 +209,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(put object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -217,7 +217,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -232,7 +232,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                             "clamd_output": "FOUND, After him, Garry!",
                             "dm_trace_id": mock.ANY,
                             "file_name": "too ducky.puddeny-pie.pdf",
-                            "object_key": "sandman/4321-billy-winks.pdf",
+                            "object_key": "sandman/+4321 billy-winks☾.pdf",
                             "object_version": "0",
                             "sns_message_id": "<N/A>",
                         },
@@ -270,7 +270,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -279,7 +279,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         AnySupersetOf({"extra": AnySupersetOf({
                             "av_status": {},
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -287,7 +287,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -309,7 +309,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -317,7 +317,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(put object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -325,7 +325,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -340,7 +340,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                             "clamd_output": "FOUND, eicar-test-signature",
                             "dm_trace_id": mock.ANY,
                             "file_name": "too ducky.puddeny-pie.pdf",
-                            "object_key": "sandman/4321-billy-winks.pdf",
+                            "object_key": "sandman/+4321 billy-winks☾.pdf",
                             "object_version": "0",
                             "sns_message_id": "<N/A>",
                         },
@@ -374,7 +374,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -383,7 +383,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         AnySupersetOf({"extra": AnySupersetOf({
                             "av_status": {},
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -391,7 +391,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -407,7 +407,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Failed handling.*UnknownClamdError.*"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -451,7 +451,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -460,7 +460,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         AnySupersetOf({"extra": AnySupersetOf({
                             "av_status": {},
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -468,7 +468,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -490,7 +490,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -519,7 +519,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -565,7 +565,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -574,7 +574,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         AnySupersetOf({"extra": AnySupersetOf({
                             "av_status": {},
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -582,7 +582,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(initiate object download"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -604,7 +604,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -633,7 +633,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -673,7 +673,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -686,7 +686,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                             },
                             "existing_av_status_result": "pass",
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -694,7 +694,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -732,7 +732,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.DEBUG, AnyStringMatching(r"Call to S3 \(get object tagging"), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -745,7 +745,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                             },
                             "existing_av_status_result": "fail",
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),
@@ -753,7 +753,7 @@ class TestScanAndTagS3Object(BaseApplicationTest):
                         (logging.INFO, AnyStringMatching(r"Handled bucket "), ()),
                         AnySupersetOf({"extra": AnySupersetOf({
                             "s3_bucket_name": "spade",
-                            "s3_object_key": "sandman/4321-billy-winks.pdf",
+                            "s3_object_key": "sandman/+4321 billy-winks☾.pdf",
                             "s3_object_version": "0",
                         })}),
                     ),


### PR DESCRIPTION
https://trello.com/c/l2On3zPU

Turns out s3 key is url-quoted in SNS events. who knew?

> The s3 key provides information about the bucket and object involved in the event. The object key name value is URL encoded. For example, "red flower.jpg" becomes "red+flower.jpg" (Amazon S3 returns "application/x-www-form-urlencoded" as the content type in the response).

https://docs.aws.amazon.com/AmazonS3/latest/dev/notification-content-structure.html

Also improve the tests to use a weirder key name.