### PR TITLE
Update package libclamunrar7 to libclamunrar9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN echo "deb http://http.debian.net/debian/ stretch main contrib non-free" > /e
         build-essential \
         clamav-daemon=${CLAMAV_VERSION}* \
         clamav-freshclam=${CLAMAV_VERSION}* \
-        libclamunrar7 \
+        libclamunrar9 \
         wget && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Ticket: https://trello.com/c/z7NZeoWF/1126-antivirus-api-failing-to-build