### PR TITLE
Enable Travis checks for Python 3.7 and 3.8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,12 +4,13 @@
 # F401: 'identifier' imported but unused
 # E402: module level import not at top of file
 # W503: line break before binary operator
+# W504: line break after binary operator
 exclude = venv*,__pycache__,node_modules,bower_components
-ignore = D203,W503
+ignore = D203,W503,W504
 max-complexity = 16
 max-line-length = 120
 per-file-ignores =
     **/__init__.py : F401
-    app/callbacks/__init__.py : E402
-    app/main/__init__.py : E402
-    app/status/__init__.py : E402
+    app/callbacks/__init__.py : E402, F401
+    app/main/__init__.py : E402, F401
+    app/status/__init__.py : E402, F401

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python:
   - "3.6"
+  - "3.7"
+  - "3.8"
 before_install:
   - export BOTO_CONFIG=/dev/null
 install:

--- a/requirements-app.txt
+++ b/requirements-app.txt
@@ -8,4 +8,4 @@ lxml==4.2.5
 validatesns==0.1.1
 psutil==5.4.8
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.1.0#egg=digitalmarketplace-utils==50.1.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
 
 # For tests
-git+https://github.com/alphagov/digitalmarketplace-test-utils.git@1.4.0#egg=digitalmarketplace-test-utils==1.4.0
+git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1
 coverage==3.7.1
 flake8-per-file-ignores==0.4.0
 flake8==3.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,12 +3,11 @@
 # For tests
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1
 coverage==3.7.1
-flake8-per-file-ignores==0.4.0
-flake8==3.5.0
+flake8==3.7.7
 freezegun==0.3.10
 mock==2.0.0
 moto==1.3.7
-pycodestyle==2.3.0
+pycodestyle==2.5.0
 pytest-cov==2.5.1
 pytest==3.2.3
 python-coveralls==2.5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,15 +2,15 @@
 
 # For tests
 git+https://github.com/alphagov/digitalmarketplace-test-utils.git@2.6.1#egg=digitalmarketplace-test-utils==2.6.1
-coverage==3.7.1
+coverage==4.4
 flake8==3.7.7
 freezegun==0.3.10
 mock==2.0.0
 moto==1.3.7
 pycodestyle==2.5.0
-pytest-cov==2.5.1
-pytest==3.2.3
-python-coveralls==2.5.0
+pytest-cov==2.7.1
+pytest==4.6.3
+python-coveralls==2.9.3
 python-dotenv==0.10.3  # used to load .flaskenv
 requests-mock==1.5.2
 testfixtures==6.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,14 +9,14 @@ lxml==4.2.5
 validatesns==0.1.1
 psutil==5.4.8
 
-git+https://github.com/alphagov/digitalmarketplace-utils.git@50.0.0#egg=digitalmarketplace-utils==50.0.0
+git+https://github.com/alphagov/digitalmarketplace-utils.git@50.1.0#egg=digitalmarketplace-utils==50.1.0
 
 ## The following requirements were added by pip freeze:
 asn1crypto==1.2.0
 blinker==1.4
-boto3==1.10.16
-botocore==1.13.16
-certifi==2019.9.11
+boto3==1.10.28
+botocore==1.13.28
+certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
 Click==7.0


### PR DESCRIPTION
https://trello.com/c/GsDBHBo7/135-switch-on-python-37-and-38-travis-checks-to-check-potential-dependency-problems-before-upgrade

- Bumps utils and test utils
- Enables Travis checks for Python 3.7 and 3.8
- Upgrades flake8 and removes `flake8-per-file-ignores` dependency