### PR TITLE
supervisord.conf: scrub potentially sensitive environment variables not needed by clam daemons

### DIFF
--- a/config/additional-supervisord.conf
+++ b/config/additional-supervisord.conf
@@ -1,5 +1,7 @@
 [program:freshclam]
 command = freshclam -d
+# scrub potentially sensitive environment variables we don't need
+environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout
@@ -11,6 +13,8 @@ stopsignal = INT
 
 [program:clamd]
 command = clamd
+# scrub potentially sensitive environment variables we don't need
+environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout


### PR DESCRIPTION
clamav daemons run as a low privilege user and in doing this we should be removing their only means of accessing sensitive values provided to the app.

This notably includes the notify key. Tested on preview with smoulder tests & it works.

We could do similar things to our base image too, perhaps removing these envs from `nginx`/`awslogs` etc...