### PR TITLE
Allow multiple Eicar test signatures

### DIFF
--- a/app/s3.py
+++ b/app/s3.py
@@ -251,7 +251,7 @@ def scan_and_tag_s3_object(
 
             if (
                 len(clamd_result) >= 2 and
-                clamd_result[1].lower() == current_app.config["DM_EICAR_TEST_SIGNATURE_RESULT_STRING"].lower()
+                clamd_result[1].lower() in map(str.lower, current_app.config["DM_EICAR_TEST_SIGNATURE_RESULT_STRINGS"])
             ):
                 notify_kwargs = {
                     # we'll use the s3 ETag of the file as the notify ref - it will be the only piece of information

--- a/config.py
+++ b/config.py
@@ -25,7 +25,10 @@ class Config:
     # only used as a surrogate where it doesn't actually matter (e.g. for s3)
     DM_DEFAULT_AWS_REGION = "eu-west-1"
 
-    DM_EICAR_TEST_SIGNATURE_RESULT_STRING = "Eicar-Test-Signature"
+    DM_EICAR_TEST_SIGNATURE_RESULT_STRINGS = [
+        "Clamav.Test.File-7",
+        "Eicar-Test-Signature"
+    ]
     DM_EICAR_TEST_SIGNATURE_VIRUS_ALERT_EMAIL = "eicar-found@example.gov.uk"
     DM_DEVELOPER_VIRUS_ALERT_EMAIL = "developer-virus-alert@example.com"
     NOTIFY_TEMPLATES = {


### PR DESCRIPTION
https://trello.com/c/zH4wrBoU/1417-smoulder-tests-eicar-files-being-sent-to-2nd-line-email-rather-than-simulator

The Eicar test signature changed, so our smoulder tests started sending the alerts to the real 2nd line email address.

I've updated the code to allow a list of Eicar test strings (just in case the old signature re-appears as mysteriously as it left...)

