### PR TITLE
Update werkzeug imports

### DIFF
--- a/app/main/views/scan.py
+++ b/app/main/views/scan.py
@@ -73,7 +73,7 @@ def scan_s3_object(body_dict):
                 f"bucket {body_dict['bucketName']!r}",
             )
         elif e.response.get("Error", {}).get("Code") == "403":
-            current_app.logger.warn(e)
+            current_app.logger.warning(e)
             abort(
                 400,
                 f"Access to key {body_dict['objectKey']!r} version {body_dict['objectVersionId']!r} in bucket "

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,10 @@ git+https://github.com/alphagov/digitalmarketplace-utils.git@51.0.0#egg=digitalm
 ## The following requirements were added by pip freeze:
 asn1crypto==1.3.0
 blinker==1.4
-boto3==1.11.9
-botocore==1.14.9
+boto3==1.11.14
+botocore==1.14.14
 certifi==2019.11.28
-cffi==1.13.2
+cffi==1.14.0
 chardet==3.0.4
 Click==7.0
 contextlib2==0.6.0.post1
@@ -26,9 +26,9 @@ defusedxml==0.6.0
 docopt==0.6.2
 docutils==0.15.2
 Flask-gzip==0.2
-Flask-Login==0.4.1
+Flask-Login==0.5.0
 Flask-Script==2.0.6
-Flask-WTF==0.14.2
+Flask-WTF==0.14.3
 fleep==1.0.1
 future==0.18.2
 gds-metrics==0.2.0
@@ -49,10 +49,10 @@ python-dateutil==2.8.1
 python-json-logger==0.1.11
 pytz==2019.3
 requests==2.22.0
-s3transfer==0.3.2
+s3transfer==0.3.3
 six==1.14.0
 unicodecsv==0.14.1
 urllib3==1.25.8
-Werkzeug==0.16.1
+Werkzeug==1.0.0
 workdays==1.4
 WTForms==2.2.1

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -11,7 +11,7 @@ import pytest
 import requests
 import requests_mock
 import validatesns
-import werkzeug
+from werkzeug.exceptions import BadRequest
 
 from dmtestutils.comparisons import AnySupersetOf, AnyStringMatching, RestrictedAny
 
@@ -221,7 +221,7 @@ class TestHandleSubscriptionConfirmation(BaseCallbackApplicationTest):
                     # rmock_response_kwargs
                     {"text": "dummy"},
                     # expected_output
-                    werkzeug.exceptions.BadRequest,
+                    BadRequest,
                     # expect_request_made
                     False,
                     # expected_log_calls
@@ -281,7 +281,7 @@ class TestHandleSubscriptionConfirmation(BaseCallbackApplicationTest):
                     # rmock_response_kwargs
                     {"text": "<Second drink<does it<"},
                     # expected_output
-                    werkzeug.exceptions.BadRequest,
+                    BadRequest,
                     # expect_request_made
                     True,
                     # expected_log_calls
@@ -317,7 +317,7 @@ class TestHandleSubscriptionConfirmation(BaseCallbackApplicationTest):
                     # rmock_response_kwargs
                     rmock_response_kwargs,
                     # expected_output
-                    werkzeug.exceptions.BadRequest,
+                    BadRequest,
                     # expect_request_made
                     True,
                     # expected_log_calls


### PR DESCRIPTION
https://trello.com/c/aQbWtees/1419-resolve-pyup-prs

The new version of Werkzeug introduces breaking changes for direct imports. We had been using `import werkzeug` to give us explicit namespacing to differentiate between `werkzeug.exceptions` and `requests.exceptions`, but given we've still got the latter, I think it's fine.

The tests now run 100% green with no warnings 😸 