### PR TITLE
supervisord.conf: use multiline strings for environment setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:9.0.0
+FROM digitalmarketplace/base-api:9.1.0
 
 ENV CLAMAV_VERSION 0.
 

--- a/config/additional-supervisord.conf
+++ b/config/additional-supervisord.conf
@@ -1,7 +1,12 @@
 [program:freshclam]
 command = freshclam -d
 # scrub potentially sensitive environment variables we don't need
-environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
+environment = AWS_ACCESS_KEY_ID="",
+    AWS_SECRET_ACCESS_KEY="",
+    DM_ANTIVIRUS_API_AUTH_TOKENS="",
+    DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",
+    DM_DEVELOPER_VIRUS_ALERT_EMAIL="",
+    DM_NOTIFY_API_KEY="",
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout
@@ -14,7 +19,12 @@ stopsignal = INT
 [program:clamd]
 command = clamd
 # scrub potentially sensitive environment variables we don't need
-environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
+environment = AWS_ACCESS_KEY_ID="",
+    AWS_SECRET_ACCESS_KEY="",
+    DM_ANTIVIRUS_API_AUTH_TOKENS="",
+    DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",
+    DM_DEVELOPER_VIRUS_ALERT_EMAIL="",
+    DM_NOTIFY_API_KEY="",
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout


### PR DESCRIPTION
Stemming from https://trello.com/c/oGLgZAoJ

Didn't know we could do this before. See https://docs.python.org/3/library/configparser.html#supported-ini-file-structure

Also bumped docker base image to incorporate similar changes made to base `supervisord.conf`