### PR TITLE
Revert "supervisord.conf: use multiline strings for environment setting"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:9.1.0
+FROM digitalmarketplace/base-api:9.0.0
 
 ENV CLAMAV_VERSION 0.
 

--- a/config/additional-supervisord.conf
+++ b/config/additional-supervisord.conf
@@ -1,12 +1,7 @@
 [program:freshclam]
 command = freshclam -d
 # scrub potentially sensitive environment variables we don't need
-environment = AWS_ACCESS_KEY_ID="",
-    AWS_SECRET_ACCESS_KEY="",
-    DM_ANTIVIRUS_API_AUTH_TOKENS="",
-    DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",
-    DM_DEVELOPER_VIRUS_ALERT_EMAIL="",
-    DM_NOTIFY_API_KEY="",
+environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout
@@ -19,12 +14,7 @@ stopsignal = INT
 [program:clamd]
 command = clamd
 # scrub potentially sensitive environment variables we don't need
-environment = AWS_ACCESS_KEY_ID="",
-    AWS_SECRET_ACCESS_KEY="",
-    DM_ANTIVIRUS_API_AUTH_TOKENS="",
-    DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",
-    DM_DEVELOPER_VIRUS_ALERT_EMAIL="",
-    DM_NOTIFY_API_KEY="",
+environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-antivirus-api#66 - I forgot to check the webserver still had permission to connecto to the `clamd` socket.