### PR TITLE
Reinstate docker base 9.1.0 bump, with permissions fix in place

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:9.0.0
+FROM digitalmarketplace/base-api:9.1.0
 
 ENV CLAMAV_VERSION 0.
 
@@ -27,7 +27,8 @@ RUN mkdir /var/run/clamav && \
 RUN sed -i 's/^Foreground .*$/Foreground true/g' /etc/clamav/clamd.conf && \
     echo "TCPSocket 3310" >> /etc/clamav/clamd.conf
 
-RUN usermod -a -G clamav www-data
+# web server needs access to the clamd socket
+RUN usermod -a -G clamav uwsgi
 
 COPY config/freshclam.conf /etc/clamav
 

--- a/config/additional-supervisord.conf
+++ b/config/additional-supervisord.conf
@@ -1,7 +1,12 @@
 [program:freshclam]
 command = freshclam -d
 # scrub potentially sensitive environment variables we don't need
-environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
+environment = AWS_ACCESS_KEY_ID="",
+    AWS_SECRET_ACCESS_KEY="",
+    DM_ANTIVIRUS_API_AUTH_TOKENS="",
+    DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",
+    DM_DEVELOPER_VIRUS_ALERT_EMAIL="",
+    DM_NOTIFY_API_KEY="",
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout
@@ -14,7 +19,12 @@ stopsignal = INT
 [program:clamd]
 command = clamd
 # scrub potentially sensitive environment variables we don't need
-environment = AWS_ACCESS_KEY_ID="",AWS_SECRET_ACCESS_KEY="",DM_ANTIVIRUS_API_AUTH_TOKENS="",DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",DM_NOTIFY_API_KEY="",DM_DEVELOPER_VIRUS_ALERT_EMAIL=""
+environment = AWS_ACCESS_KEY_ID="",
+    AWS_SECRET_ACCESS_KEY="",
+    DM_ANTIVIRUS_API_AUTH_TOKENS="",
+    DM_ANTIVIRUS_API_CALLBACK_AUTH_TOKENS="",
+    DM_DEVELOPER_VIRUS_ALERT_EMAIL="",
+    DM_NOTIFY_API_KEY="",
 autostart = true
 autorestart = true
 stdout_logfile = /dev/stdout


### PR DESCRIPTION
Needed to switch the user we grant the `clamav` group membership to because the user we run the web server as changed.