### PR TITLE
bump docker image version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:9.2.0
+FROM digitalmarketplace/base-api:9.4.0
 
 ENV CLAMAV_VERSION 0.
 


### PR DESCRIPTION
bump docker version to pick up changes from alphagov/digitalmarketplace-docker-base#74