### PR TITLE
Switch from LXML to defusedxml

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -5,8 +5,8 @@ Flask==1.0.4         # pyup: >=1.0.4,<1.1.0
 itsdangerous==1.1.0  # pyup: >=1.1.0,<1.2.0
 
 clamd==1.0.2
-lxml==4.6.2
 validatesns==0.1.1
 psutil==5.8.0
+defusedxml==0.6.0
 
 git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,9 @@ contextlib2==0.6.0.post1
 cryptography==3.2.1
     # via digitalmarketplace-utils
 defusedxml==0.6.0
-    # via odfpy
+    # via
+    #   -r requirements.in
+    #   odfpy
 git+https://github.com/alphagov/digitalmarketplace-utils.git@54.1.1#egg=digitalmarketplace-utils==54.1.1
     # via -r requirements.in
 docopt==0.6.2
@@ -71,8 +73,6 @@ jmespath==0.9.5
     # via
     #   boto3
     #   botocore
-lxml==4.6.2
-    # via -r requirements.in
 mailchimp3==3.0.6
     # via digitalmarketplace-utils
 markupsafe==1.1.1

--- a/tests/callbacks/views/test_sns.py
+++ b/tests/callbacks/views/test_sns.py
@@ -5,7 +5,7 @@ from urllib.parse import quote_plus
 
 from freezegun import freeze_time
 from flask.wrappers import Response
-from lxml.etree import ParseError
+from defusedxml.ElementTree import ParseError
 import mock
 import pytest
 import requests


### PR DESCRIPTION
LXML is vulnerable to denial of service attacks when parsing untrusted documents.

Unfortunately, defusedxml lacks a couple of key features which we were using from LXML; namely good XPath support and the ability to get an element's namespace.

The only way of identifying an element's namespace in defusedxml is through the string representation of the element where it will appear as `"<Element '{http://an.example.namespace.com}ConfirmSubscriptionResponse' at 0x10e7fe4a8>"`

If there is a namespace, extract it from the string representation and insert it into the search string.

We can no longer get the contents of an element in the XPath, so we have to use a different XPath in `Element.find()`. This returns `None` if there's not a match, so wrap each search in a `try/except` block so we can maintain the behaviour of returning an empty string if an element isn't found.

https://trello.com/c/HtkcGEV4/811-2-address-ithc-issue-631-xml-parsing-timebox-2-days