### PR TITLE
Replace make with invoke

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,3 +14,4 @@ per-file-ignores =
     app/callbacks/__init__.py : E402, F401
     app/main/__init__.py : E402, F401
     app/status/__init__.py : E402, F401
+    tasks.py: F401

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,9 +22,12 @@ jobs:
         key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('**/requirements*.txt') }}
         restore-keys: venv-${{ runner.os }}-${{ matrix.python-version }}-
 
+    - name: Install developer tools
+      run: make bootstrap
+
     - name: Install python dependencies
-      run: make requirements-dev
+      run: invoke requirements-dev
       if: steps.python-cache.outputs.cache-hit != 'true'
 
     - name: Run python tests
-      run: make test
+      run: invoke test

--- a/Makefile
+++ b/Makefile
@@ -1,53 +1,21 @@
-SHELL := /bin/bash
-VIRTUALENV_ROOT := $(shell [ -z $$VIRTUAL_ENV ] && echo $$(pwd)/venv || echo $$VIRTUAL_ENV)
 
-.PHONY: run-all
-run-all: requirements run-app
+.DEFAULT_GOAL := bootstrap
 
-.PHONY: run-app
-run-app: virtualenv
-	${VIRTUALENV_ROOT}/bin/flask run
+%:
+	-@[ -z "$$TERM" ] || tput setaf 1  # red
+	@>&2 echo warning: calling '`make`' is being deprecated in this repo, you should use '`invoke` (https://pyinvoke.org)' instead.
+	-@[ -z "$$TERM" ] || tput setaf 9  # default
+	@# pass goals to '`invoke`'
+	invoke $(or $(MAKECMDGOALS), $@)
+	@exit
 
-.PHONY: virtualenv
-virtualenv:
-	[ -z $$VIRTUAL_ENV ] && [ ! -d venv ] && python3 -m venv venv || true
+help:
+	invoke --list
 
-.PHONY: upgrade-pip
-upgrade-pip:
-	${VIRTUALENV_ROOT}/bin/pip install --upgrade pip
-
-.PHONY: requirements
-requirements: virtualenv upgrade-pip requirements.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt
-
-.PHONY: requirements-dev
-requirements-dev: virtualenv upgrade-pip requirements.txt requirements-dev.txt
-	${VIRTUALENV_ROOT}/bin/pip install -r requirements.txt -r requirements-dev.txt
-
-.PHONY: freeze-requirements
-freeze-requirements: virtualenv requirements-dev requirements.in requirements-dev.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements.in
-	${VIRTUALENV_ROOT}/bin/pip-compile requirements-dev.in
-
-.PHONY: test
-test: test-flake8 test-unit
-
-.PHONY: test-flake8
-test-flake8: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/flake8 .
-
-.PHONY: test-unit
-test-unit: virtualenv requirements-dev
-	${VIRTUALENV_ROOT}/bin/py.test ${PYTEST_ARGS}
-
-.PHONY: docker-build
-docker-build:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	@echo "Building a docker image for ${RELEASE_NAME}..."
-	docker build -t digitalmarketplace/antivirus-api --build-arg release_name=${RELEASE_NAME} .
-	docker tag digitalmarketplace/antivirus-api digitalmarketplace/antivirus-api:${RELEASE_NAME}
-
-.PHONY: docker-push
-docker-push:
-	$(if ${RELEASE_NAME},,$(eval export RELEASE_NAME=$(shell git describe)))
-	docker push digitalmarketplace/antivirus-api:${RELEASE_NAME}
+.PHONY: bootstrap
+bootstrap:
+	pip install digitalmarketplace-developer-tools
+	@echo done
+	-@[ -z "$$TERM" ] || tput setaf 2  # green
+	@>&2 echo dmdevtools has been installed globally, run developer tasks with '`invoke`'
+	-@[ -z "$$TERM" ] || tput setaf 9  # default

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,1 @@
+from dmdevtools.invoke_tasks import api_app_tasks as ns


### PR DESCRIPTION
We want to be able to reduce duplication of code across our repos; one of the places we have a lot of duplicated code is in our Makefiles; all of our repos have very similar Makefiles with small historical differences.

This commit replaces Make with invoke, using the tasks from alphagov/digitalmarketplace-developer-tools.