### PR TITLE
Remove wget

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN echo "deb http://http.debian.net/debian/ buster main contrib non-free" > /et
         clamav-daemon=${CLAMAV_VERSION}* \
         clamav-freshclam=${CLAMAV_VERSION}* \
         libclamunrar9 \
-        wget && \
+        && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Because we no longer use wget to download virus definitions, we no longer need wget in our Docker image. This PR stops it from being installed. Thanks @idavidmcdonald for pointing this out.