### PR TITLE
Add Docker to Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
   open-pull-requests-limit: 10
   allow:
   - dependency-type: production
+
+- package-ecosystem: docker
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "03:00"


### PR DESCRIPTION
We want to make sure we are using the latest version of our Docker base images, let's use Dependabot to help us with that.