### PR TITLE
remove coveralls badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
 # Digital Marketplace Antivirus API
-
-[![Coverage Status](https://coveralls.io/repos/alphagov/digitalmarketplace-antivirus-api/badge.svg?branch=master&service=github)](https://coveralls.io/github/alphagov/digitalmarketplace-antivirus-api?branch=master)
 ![Python 3.6](https://img.shields.io/badge/python-3.6-blue.svg)
 
 API application for Digital Marketplace.


### PR DESCRIPTION
we are no longer using this since switching to Github Actions.