### PR TITLE
Bump Docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM digitalmarketplace/base-api:9.6.1
+FROM digitalmarketplace/base-api:10.0.1
 
 ENV CLAMAV_VERSION 0.
 


### PR DESCRIPTION
Pulls in alphagov/digitalmarketplace-docker-base#82 which fixes issues installing Python `cryptography` module.