### PR TITLE
Upgrade Flask to 1.1.4

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,8 +1,8 @@
 # Run `make freeze-requirements` to update requirements.txt
 # with package version changes made in requirements.in
 
-Flask==1.0.4         # pyup: >=1.0.4,<1.1.0
-itsdangerous==2.0.1  # pyup: >=1.1.0,<1.2.0
+Flask>=1.1,<2
+itsdangerous
 
 clamd==1.0.2
 validatesns==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ defusedxml==0.7.1
     # via
     #   -r requirements.in
     #   odfpy
-digitalmarketplace-utils==58.1.0
+digitalmarketplace-utils==59.0.0
     # via -r requirements.in
 docopt==0.6.2
     # via notifications-python-client
@@ -48,7 +48,7 @@ flask-session==0.3.2
     # via digitalmarketplace-utils
 flask-wtf==0.14.3
     # via digitalmarketplace-utils
-flask==1.0.4
+flask==1.1.4
     # via
     #   -r requirements.in
     #   digitalmarketplace-utils
@@ -67,7 +67,7 @@ govuk-country-register==0.5.0
     # via digitalmarketplace-utils
 idna==2.9
     # via requests
-itsdangerous==2.0.1
+itsdangerous==1.1.0
     # via
     #   -r requirements.in
     #   flask
@@ -126,9 +126,7 @@ urllib3==1.25.10
 validatesns==0.1.1
     # via -r requirements.in
 werkzeug==1.0.0
-    # via
-    #   digitalmarketplace-utils
-    #   flask
+    # via flask
 workdays==1.4
     # via digitalmarketplace-utils
 wtforms==2.2.1


### PR DESCRIPTION
Get the updated version of `digitalmarketplace-utils` to support this.

Flask 1.1.x requires `itsdangerous` < 2.0.0, so loosen the version requirements. Pin Flask requirements to 1.1 or greater, but less than 2. Flask 1.1 is the last planned v1 release before 2.0.0, so take patch versions of 1.1 for security but not 2.0 which we're not ready for yet.

Also get rid of pyup comments - we're using dependabot instead now

https://trello.com/c/obh5gpQp/2250-update-to-flask-114