### PR TITLE
Use updated Docker image base (v12 - python:3.9-slim-bullseye)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,14 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v10.1
+
+    - name: Build Dockerfile
+      if: contains(steps.changed-files.outputs.modified_files, 'Dockerfile')
+      run: docker build .
+
     - name: Setup python (${{ matrix.python-version }})
       uses: actions/setup-python@v2
       with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM digitalmarketplace/base-api:11.0.0
+FROM digitalmarketplace/base-api:12.0.0
 
 ENV CLAMAV_VERSION 0.
 
-RUN echo "deb http://http.debian.net/debian/ buster main contrib non-free" > /etc/apt/sources.list && \
-    echo "deb http://http.debian.net/debian/ buster-updates main contrib non-free" >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org/ buster/updates main contrib non-free" >> /etc/apt/sources.list && \
+RUN echo "deb http://deb.debian.org/debian bullseye main contrib non-free" > /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian bullseye-updates main contrib non-free" >> /etc/apt/sources.list && \
+    echo "deb http://deb.debian.org/debian-security/ bullseye-security main contrib non-free" >> /etc/apt/sources.list && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         build-essential \


### PR DESCRIPTION
https://trello.com/c/fK12wIdi/204-update-docker-images-to-use-newer-version-of-debian

Updated the docker file to use v12 of the base image which has updated the debian version from buster to bullseye.

I also updated the source files in the Dockerfile, now with the source for [bullseye](https://wiki.debian.org/SourcesList)

Finally, I added the Docker build to github actions so that we can test that the Dockerfile does build properly